### PR TITLE
Add config example file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ Minutes are optional, and decimal degrees are supported.
 
 ## Notes
 
-The file `config.js` (containing your API key) and `.env` are ignored by Git. Do not commit your secret key to version control.
+The file `config.js` (containing your API key) and `.env` are ignored by Git. A template `config.example.js` is provided for convenience. Do not commit your secret key to version control.

--- a/config.example.js
+++ b/config.example.js
@@ -1,0 +1,3 @@
+// Copy to config.js and insert your RapidAPI key
+const RAPIDAPI_KEY = 'YOUR_RAPIDAPI_KEY_HERE';
+export default RAPIDAPI_KEY;


### PR DESCRIPTION
## Summary
- provide `config.example.js` with placeholder RapidAPI key
- document the example config file in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688468775760832f92ee22dc8b89fb79