### PR TITLE
Fix astrology error detail string

### DIFF
--- a/netlify/functions/astrology.js
+++ b/netlify/functions/astrology.js
@@ -57,6 +57,11 @@ exports.handler = async function(event) {
     const apiResponse = await fetch(API_BASE_URL, options);
     const apiData = await apiResponse.json();
 
+    // Ensure error details are always returned as a readable string
+    if (apiData && typeof apiData.detail !== 'string' && apiData.detail !== undefined) {
+      apiData.detail = JSON.stringify(apiData.detail);
+    }
+
     if (!apiResponse.ok) {
       return {
         statusCode: apiResponse.status,


### PR DESCRIPTION
## Summary
- ensure the astrology API detail field is always returned as a readable string

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68889d88f2b4832fa8a6cb6b353d87c4