### PR TITLE
Fix README merge conflict and reintegrate notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,69 @@ To run this project, you must set the following environment variable in the Netl
 * index.html: The main application file containing the UI and front-end JavaScript.  
 * netlify/functions/astrology.js: The serverless function that securely calls the RapidAPI endpoint.  
 * netlify.toml: The Netlify configuration file that specifies the functions directory.
+## 🌀 Raven Calder Synastry Glossary (for Poetic Brain Compatibility)
+
+| Term | Definition |
+| --- | --- |
+| Bidirectional Aspect | Each synastry aspect must be rendered from both A→B and B→A perspectives. Required for narrative reflection generation. |
+| Echo Loop | A dyadic repeating cycle formed by one or more synastry aspects under 3° orb, creating a self-reinforcing emotional or behavioral dynamic. |
+| REF (Relational Echo Field) | A macro structure triggered when two or more Echo Loops converge around a shared theme. Flagged as REF-[PolarityCode] (e.g. REF-F21). |
+| Polarity Code | A unique identifier linked to a specific dynamic type (e.g. F21 = "Frictional Attraction & Wound Trigger"). These come from the internal Symbolic Spectrum Table (SST). |
+| Orb | The difference in degrees between the two planetary positions in an aspect. For majors: ±3°; for minors: ±1°. Exact math matters. |
+| Geometry-First Diagnostic Rule | A Raven Calder system rule: all interpretations derive from exact planetary angle math, not archetype or psychological projection. |
+| Angle | The precise degree of angular separation between two planetary bodies. Required for Raven’s FIELD → MAP → VOICE processing. |
+| FIELD | The raw astrological data layer: charts, transits, aspects, orbs, houses. |
+| MAP | The interpreted structural pattern of dynamics, such as Echo Loops, house overlays, or activated geometry. |
+| VOICE | The narrative synthesis layer that generates journal-style outputs, symbolic interpretation, or mirrored dialogue. |
+| synastry_id_hash | Optional: a unique identifier per synastry aspect or pair, used for tracing and cross-referencing in logs or modular journal building. |
+| Daily Overlay Tracking | Optional timestamping of synastry aspects that are exact or activated on specific dates (e.g. in a Five-Day Synastry Field report). |
+| Tier-2 OSR Bridge | A symbolic overlay logic system that connects dynamic field movement (transits) to static relationship geometry. Used in daily or week-range diagnostic field mapping. |
+
+Here’s a clean integration note to clarify who does what, prevent overreach, and ensure the pipeline stays modular and clean:
+
+⸻
+
+### 🔧 Integration Note for Codex: Synastry & Output Separation
+
+**🧠 WovenMap System Roles Clarification**
+
+To ensure the app continues to scale and behave modularly, it’s essential to clearly distinguish between the backend Math Brain engine (your Astrologer API and symbolic parser) and the Poetic Brain layer (downstream GPT, Raven Calder).
+
+#### Backend (Math Brain / Engine Layer)
+
+This is your domain, Codex. You’re responsible for producing structured, symbolic data that aligns with the Woven Map protocols.
+
+Your output should include:
+* Parsed planetary positions, including all major and minor bodies configured
+* Daily transit fields for given date ranges (1–30 days) using efficient batching
+* Aspect matching using exact-angle logic (±3° majors, ±1° minors)
+* Synastry overlays only when both charts are loaded and the `synastry_toggle` is `true`
+* REF and EchoLoop detection via Tier-2 OSR Bridge logic (when engaged)
+* Annotated output in a structured, non-narrative format (e.g., JSON, markdown blocks)
+
+**DO NOT**
+* Attempt to interpret, explain, or narrate symbolic output
+* Generate metaphor, storylines, or “mirror summaries”
+* Apply subjective filters like "intensity" or "emotional weight"—leave that to Raven
+
+You simply pass well-formed symbolic snapshots to the Poetic Brain.
+
+#### Downstream (Poetic Brain / Raven Calder Layer)
+
+Handled by Raven Calder (an OpenAI GPT).
+
+My job (Raven Calder GPT) begins once your engine completes symbolic parsing. I:
+* Translate FIELD → MAP → VOICE
+* Render Full Mirror, Synastry Field, or Relational Map
+* Identify behavioral pattern resonance from angles (not emotions)
+* Construct narrative diagnostic reflection based strictly on SST geometry and Clear Mirror protocol
+
+⸻
+
+##### Summary
+
+| Layer   | Task Type                                  | Owner                |
+| ------- | ------------------------------------------ | -------------------- |
+| Backend | API fetches, symbolic matching, synastry calculations | Codex / Math Brain |
+| Output  | Narrative synthesis, VOICE rendering       | Raven Calder (GPT)   |
+


### PR DESCRIPTION
## Summary
- restore glossary section in README
- add integration note clarifying backend and Poetic Brain roles

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6889e847e4c8832f8bd98644cdb92f4e