### PR TITLE
Fix incomplete openapi JSON

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4439,6 +4439,19 @@
         "title": "ValidationError"
       }
     },
+      "SynastryRequestModel": {
+        "type": "object",
+        "required": ["first_subject", "second_subject"],
+        "properties": {
+          "first_subject": {
+            "$ref": "#/components/schemas/SubjectModel"
+          },
+          "second_subject": {
+            "$ref": "#/components/schemas/SubjectModel"
+          }
+        },
+        "title": "SynastryRequestModel"
+      },
     "securitySchemes": {
       "RapidAPIKey": {
         "type": "apiKey",
@@ -4453,15 +4466,3 @@
     }
   ]
 }
-      "SynastryRequestModel": {
-        "type": "object",
-        "required": ["first_subject", "second_subject"],
-        "properties": {
-          "first_subject": {
-            "$ref": "#/components/schemas/SubjectModel"
-          },
-          "second_subject": {
-            "$ref": "#/components/schemas/SubjectModel"
-          }
-        }
-      },


### PR DESCRIPTION
## Summary
- add missing `SynastryRequestModel` schema inside the `components` section
- close JSON structures properly so the OpenAPI spec is valid

## Testing
- `python3 -m json.tool openapi.json >/dev/null`

------
https://chatgpt.com/codex/tasks/task_e_688abdbd4628832fbdb245634e14b367