### PR TITLE
Handle API failures in astrology function

### DIFF
--- a/netlify/functions/astrology.js
+++ b/netlify/functions/astrology.js
@@ -50,17 +50,27 @@ exports.handler = async function (event) {
       });
 
       const rawText = await response.text();
-      try {
+
+      if (!response.ok) {
         return {
-          statusCode: 200,
+          statusCode: response.status,
           body: rawText
         };
-      } catch (e) {
+      }
+
+      try {
+        JSON.parse(rawText);
+      } catch {
         return {
           statusCode: 502,
           body: JSON.stringify({ error: 'Malformed response from API' })
         };
       }
+
+      return {
+        statusCode: 200,
+        body: rawText
+      };
     }
 
     // Natal request
@@ -83,6 +93,23 @@ exports.handler = async function (event) {
       });
 
       const rawText = await response.text();
+
+      if (!response.ok) {
+        return {
+          statusCode: response.status,
+          body: rawText
+        };
+      }
+
+      try {
+        JSON.parse(rawText);
+      } catch {
+        return {
+          statusCode: 502,
+          body: JSON.stringify({ error: 'Malformed response from API' })
+        };
+      }
+
       return {
         statusCode: 200,
         body: rawText


### PR DESCRIPTION
## Summary
- handle response errors for natal and synastry calls in `astrology.js`
- validate API responses are JSON before returning

## Testing
- `node -c netlify/functions/astrology.js`
- `node -e "require('./netlify/functions/astrology.js')"`

------
https://chatgpt.com/codex/tasks/task_e_688ace5fb4bc832f9c3c654978b2bea7