### PR TITLE
Fix error priority in API helper

### DIFF
--- a/index.html
+++ b/index.html
@@ -434,7 +434,10 @@
 
             if (!res.ok) {
                 // Show detailed error if available
-                const errorMsg = responsePayload.error || responsePayload.details || 'An unknown server error occurred.';
+                const errorMsg =
+                    responsePayload.details ??
+                    responsePayload.error ??
+                    'An unknown server error occurred.';
                 throw new Error(errorMsg);
             }
 


### PR DESCRIPTION
## Summary
- ensure API helper prioritizes `details` over `error`

## Testing
- `npm install`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_688b22b33800832f941215ece7172765