### PR TITLE
Fix astrology error logging

### DIFF
--- a/netlify/functions/astrology.js
+++ b/netlify/functions/astrology.js
@@ -59,8 +59,8 @@ exports.handler = async function (event) {
       }
 
       const rawText = await response.text();
-      console.error('Astrology API error (synastry):', response.status, rawText);
       if (!response.ok) {
+        console.error('Astrology API error (synastry):', response.status, rawText);
         return {
           statusCode: 502,
           body: JSON.stringify({ error: 'External API error', details: rawText })
@@ -111,8 +111,8 @@ exports.handler = async function (event) {
       }
 
       const rawText = await response.text();
-      console.error('Astrology API error (natal):', response.status, rawText);
       if (!response.ok) {
+        console.error('Astrology API error (natal):', response.status, rawText);
         return {
           statusCode: 502,
           body: JSON.stringify({ error: 'External API error', details: rawText })


### PR DESCRIPTION
## Summary
- avoid logging errors when astrology API responses are successful

## Testing
- `npm run build:css`

------
https://chatgpt.com/codex/tasks/task_e_688b22b73790832fb4465289be8c86c9