### PR TITLE
Expose raw natal math in reports and tests

### DIFF
--- a/REPORT_REQUIREMENTS.md
+++ b/REPORT_REQUIREMENTS.md
@@ -6,6 +6,41 @@ This document defines the canonical requirements for astrological chart reports 
 
 ---
 
+## ✅ Raw Math Requirements
+
+Each generated report must expose the math that underwrites the mirror.
+
+1. **Provenance header** – `calculation_timestamp` (UTC ISO 8601), `software_version` (git SHA), `ephemeris`, `timezone_db_version`.
+2. **Birth data echo** – birth date/time/location, lat/lon, `tz_offset`, `rectification_status` (`exact|rounded|unknown`), `source` (`user|system`).
+3. **Configuration** – `zodiac`, `house_system`, `orbs_profile`, and `location_context` for translocation.
+4. **Planetary positions** – name, longitude, sign, degrees in sign, speed, retrograde flag, house for each body (Sun, Moon, Mercury, Venus, Mars, Jupiter, Saturn, Uranus, Neptune, Pluto, Chiron; optional Node/Lilith/Vertex).
+5. **Angles & houses** – ASC, MC, IC, DC plus 12 house cusps with longitudes and signs.
+6. **Aspect table** – rows `{a, b, type, orb_deg, phase, exact}`. Supported aspects: conjunction, opposition, square, trine, sextile (quintile optional).
+7. **Transit context** – separate transit aspect table with `transiting_body`, `natal_target`, `orb_deg`, `phase`, `location_context`, optional `exact_hits`. Seismograph rollup uses `{date, magnitude, valence, volatility, drivers[]}`.
+8. **JSON + Markdown** – include human-friendly tables and a collapsed block with the full raw JSON payload.
+
+### Default Orb Policy
+
+| Aspect      | Max Orb (deg) |
+| ----------- | ------------- |
+| Conjunction | 8 |
+| Opposition  | 8 |
+| Square      | 7 |
+| Trine       | 7 |
+| Sextile     | 5 |
+
+Moon aspects expand by +1°. Outer-to-personal tighten by −1°.
+
+### Supported Bodies
+
+Sun, Moon, Mercury, Venus, Mars, Jupiter, Saturn, Uranus, Neptune, Pluto, Chiron, optional Node, Lilith, Vertex.
+
+### Notes
+
+Missing upstream fields must render placeholders and surface a warning in the provenance block.
+
+---
+
 ## ✅ Context & Provenance
 
 ### Required Fields

--- a/astrologerAPI.md
+++ b/astrologerAPI.md
@@ -1,3 +1,31 @@
+# Astrologer API Supplement
+
+The Math Brain app expects the following endpoints to expose raw natal math.
+
+## GET /natal/positions
+Returns planetary positions, angles, and houses with fields:
+`name`, `lon_deg`, `sign`, `deg_in_sign`, `speed_deg_per_day`, `retrograde`, `house`.
+
+## GET /natal/aspects
+Returns full natal aspect grid with `a`, `b`, `type`, `orb_deg`, and `phase`.
+
+## GET /transits
+Returns transits to natal with `{transiting_body, natal_target, type, orb_deg, phase, location_context, exact_hits[]}`.
+
+Example:
+
+```json
+{
+  "natal": {
+    "planets": [{ "name":"Sun","lon_deg":45.12,"sign":"Taurus","deg_in_sign":15.12,"speed_deg_per_day":0.9856,"retrograde":false,"house":10 }],
+    "angles": { "ASC": { "lon_deg":123.33,"sign":"Leo","deg_in_sign":3.33 } },
+    "houses": [{ "num":1,"lon_deg":123.33,"sign":"Leo","deg_in_sign":3.33 }],
+    "aspects": [{ "a":"Saturn","b":"Moon","type":"square","orb_deg":3.12,"phase":"applying","exact":null }]
+  },
+  "transits": { "aspects": [] }
+}
+```
+
 {
 
 "openapi": "3.1.0", "info": {

--- a/debug-api.html
+++ b/debug-api.html
@@ -16,12 +16,14 @@
 <body>
     <h1>API Debug Test</h1>
     <p>This page tests if the Netlify function is accessible.</p>
-    
+
     <button onclick="testFunction()">Test Function Endpoint</button>
     <button onclick="testSimpleCall()">Test Simple API Call</button>
     <button onclick="testWithRealData()">Test With Real Data</button>
-    
+    <button onclick="toggleRaw()">Toggle Raw JSON</button>
+
     <div id="results"></div>
+    <pre id="raw-json" style="display:none;background:#222;padding:10px;border-radius:5px;"></pre>
 
     <script>
         function log(message, isError = false, isSuccess = false) {
@@ -64,6 +66,25 @@
             }
         }
 
+        function assertBasics(json){
+            const planets = json?.natal?.planets || [];
+            log(`Planet count: ${planets.length}`, planets.length < 11);
+            const houses = json?.natal?.houses || [];
+            log(`House count: ${houses.length}`, houses.length !== 12);
+            const aspects = json?.natal?.aspects || [];
+            log(`Aspect rows: ${aspects.length}`, aspects.length === 0);
+            const angles = json?.natal?.angles || {};
+            const hasAngles = angles.ASC && angles.MC;
+            log(`Angles ASC/MC present: ${hasAngles}`, !hasAngles);
+            const satMoon = aspects.some(a => (a.a === 'Saturn' && a.b === 'Moon') || (a.a === 'Moon' && a.b === 'Saturn'));
+            log(`Saturn↔Moon present: ${satMoon}`, !satMoon);
+        }
+
+        function toggleRaw(){
+            const pre = document.getElementById('raw-json');
+            pre.style.display = pre.style.display === 'none' ? 'block' : 'none';
+        }
+
         async function testWithRealData() {
             log('Testing with minimal valid data...');
             try {
@@ -94,7 +115,7 @@
                     },
                     relocation: { enabled: false }
                 };
-                
+
                 const response = await fetch('/.netlify/functions/astrology-mathbrain', {
                     method: 'POST',
                     headers: {
@@ -102,18 +123,16 @@
                     },
                     body: JSON.stringify(testData)
                 });
-                
-                log(`Real data response: ${response.status} - ${response.statusText}`, response.status >= 400, response.status === 200);
+
+                log(`Real data response: ${response.status} - ${response.statusText}`, response.status >= 400, response.status == 200);
                 const text = await response.text();
                 log(`Response preview: ${text.substring(0, 500)}...`);
-                
-                if (response.status === 200) {
-                    try {
-                        const json = JSON.parse(text);
-                        log(`Successfully parsed JSON response with ${Object.keys(json).length} top-level properties`, false, true);
-                    } catch (e) {
-                        log(`Response was not valid JSON: ${e.message}`, true);
-                    }
+                try {
+                    const json = JSON.parse(text);
+                    document.getElementById('raw-json').textContent = JSON.stringify(json, null, 2);
+                    assertBasics(json);
+                } catch (e) {
+                    log(`Response was not valid JSON: ${e.message}`, true);
                 }
             } catch (error) {
                 log(`Error with real data: ${error.message}`, true);

--- a/src/normalizers/astrology-normalizer.js
+++ b/src/normalizers/astrology-normalizer.js
@@ -1,0 +1,53 @@
+(function(global){
+  function mapPlanet(p){
+    if(!p) return null;
+    return {
+      name: p.name || p.body || null,
+      lon_deg: Number(p.lon_deg ?? p.longitude),
+      sign: p.sign || null,
+      deg_in_sign: Number(p.deg_in_sign ?? p.degree),
+      speed_deg_per_day: Number(p.speed_deg_per_day ?? p.speed),
+      retrograde: Boolean(p.retrograde ?? p.rx),
+      house: p.house != null ? Number(p.house) : null
+    };
+  }
+
+  function mapAspect(a){
+    if(!a) return null;
+    return {
+      a: a.a || a.point_a || null,
+      b: a.b || a.point_b || null,
+      type: a.type || a.aspect || null,
+      orb_deg: Number(a.orb_deg ?? a.orb),
+      phase: a.phase || a.applying ? 'applying' : (a.separating ? 'separating' : null),
+      exact: a.exact || null
+    };
+  }
+
+  function normalizeVendorPayload(raw){
+    raw = raw || {};
+    return {
+      provenance: {
+        calculation_timestamp: raw.calculation_timestamp || raw.timestamp || null,
+        software_version: raw.software_version || raw.git_sha || null,
+        ephemeris: raw.ephemeris || null,
+        timezone_db_version: raw.timezone_db_version || raw.tzdb || null
+      },
+      birth_data: raw.birth_data || raw.birth || {},
+      config: raw.config || {},
+      natal: {
+        planets: (raw.natal?.planets || raw.planets || []).map(mapPlanet),
+        angles: raw.natal?.angles || raw.angles || {},
+        houses: raw.natal?.houses || raw.houses || [],
+        aspects: (raw.natal?.aspects || raw.aspects || []).map(mapAspect)
+      },
+      transits: {
+        location_context: raw.transits?.location_context || raw.location_context || null,
+        aspects: (raw.transits?.aspects || []).map(mapAspect),
+        seismograph_daily: raw.transits?.seismograph_daily || []
+      }
+    };
+  }
+
+  global.normalizeAstrologyPayload = normalizeVendorPayload;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/src/reporters/raw-math-composer.js
+++ b/src/reporters/raw-math-composer.js
@@ -1,0 +1,69 @@
+(function(global){
+  function fmt(x){
+    return (x==null||x==='') ? '—' : x;
+  }
+
+  function table(headers, rows){
+    let md = `| ${headers.join(' | ')} |\n| ${headers.map(()=>':---').join(' | ')} |\n`;
+    rows.forEach(r=>{ md += `| ${r.map(fmt).join(' | ')} |\n`; });
+    return md;
+  }
+
+  function composeRawMathReport(data){
+    data = data || {};
+    const parts = [];
+
+    const natal = data.natal || {};
+    if(natal.planets){
+      const rows = natal.planets.map(p=>[
+        p.name, p.lon_deg, p.sign, p.deg_in_sign, p.speed_deg_per_day, p.retrograde, p.house
+      ]);
+      parts.push('## Natal Math (Raw)');
+      parts.push(table(['Body','Lon','Sign','Deg','Speed','Rx','House'], rows));
+    }
+    if(natal.angles || natal.houses){
+      const angleRows = [];
+      const angles = natal.angles||{};
+      Object.keys(angles).forEach(k=>{
+        const a = angles[k];
+        angleRows.push([k, a.lon_deg, a.sign, a.deg_in_sign]);
+      });
+      const houseRows = (natal.houses||[]).map(h=>[h.num, h.lon_deg, h.sign, h.deg_in_sign]);
+      parts.push('## Houses & Angles');
+      if(angleRows.length) parts.push(table(['Angle','Lon','Sign','Deg'], angleRows));
+      if(houseRows.length) parts.push(table(['House','Lon','Sign','Deg'], houseRows));
+    }
+    if(natal.aspects){
+      const rows = natal.aspects.map(a=>[a.a,a.b,a.type,a.orb_deg,a.phase||'',a.exact||'']);
+      parts.push('## Natal Aspects');
+      parts.push(table(['A','B','Type','Orb','Phase','Exact'], rows));
+    }
+
+    const transits = data.transits || {};
+    if(transits.aspects && transits.aspects.length){
+      const rows = transits.aspects.map(t=>[
+        t.transiting_body||t.a, t.natal_target||t.b, t.type, t.orb_deg, t.phase||'', t.exact||''
+      ]);
+      parts.push('## Transit Aspects');
+      parts.push(table(['Transit','Natal','Type','Orb','Phase','Exact'], rows));
+    }
+    if(transits.seismograph_daily && transits.seismograph_daily.length){
+      const rows = transits.seismograph_daily.map(s=>[
+        s.date, s.magnitude, s.valence, s.volatility, (s.drivers||[]).join('; ')
+      ]);
+      parts.push('## Seismograph Daily');
+      parts.push(table(['Date','Mag','Val','Vol','Drivers'], rows));
+    }
+
+    const prov = data.provenance || {};
+    const provRows = Object.keys(prov).map(k=>[k, prov[k]]);
+    parts.push('## Data & Provenance');
+    parts.push(table(['Field','Value'], provRows));
+
+    const jsonBlock = `<details><summary>Raw JSON</summary>\n\n\n\n<pre>${JSON.stringify(data,null,2)}</pre>\n\n</details>`;
+    parts.push(jsonBlock);
+    return parts.join('\n\n');
+  }
+
+  global.composeRawMathReport = composeRawMathReport;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/templates/sample_8.23.25.md
+++ b/templates/sample_8.23.25.md
@@ -1,0 +1,27 @@
+# Woven Map Sample Report Template
+
+## Natal Math (Raw)
+Placeholder table for planetary positions.
+
+## Houses & Angles
+Placeholder table for house cusps and angles.
+
+## Natal Aspects
+Placeholder table for natal aspects.
+
+## Transit Aspects
+Placeholder table for transit aspects when transits are requested.
+
+## Seismograph Daily
+Placeholder table for seismograph daily rollup.
+
+## Data & Provenance
+Placeholder block for provenance and configuration details.
+
+<details><summary>Raw JSON</summary>
+
+```
+{}
+```
+
+</details>

--- a/test-streamlined-api.html
+++ b/test-streamlined-api.html
@@ -21,8 +21,10 @@
     <button onclick="testSynastryTransits()">Test Synastry + Transits</button>
     <button onclick="testCompositeTransits()">Test Composite + Transits</button>
     <button onclick="testMissingTransitDates()">Test Missing Transit Dates (Should Fail)</button>
+    <button onclick="toggleRaw()">Toggle Raw JSON</button>
     
     <div id="output" class="output"></div>
+    <pre id="raw-json" style="display:none;background:#2a2a2a;padding:15px;border-radius:5px;"></pre>
 
     <script>
         const apiEndpoint = '/.netlify/functions/astrology-mathbrain';
@@ -32,6 +34,25 @@
             const className = isError ? 'error' : (isSuccess ? 'success' : '');
             output.innerHTML += `<div class="${className}">${new Date().toISOString()}: ${message}</div>`;
             output.scrollTop = output.scrollHeight;
+        }
+
+        function assertBasics(json){
+            const planets = json?.natal?.planets || [];
+            log(`Planet count: ${planets.length}`, planets.length < 11);
+            const houses = json?.natal?.houses || [];
+            log(`House count: ${houses.length}`, houses.length !== 12);
+            const aspects = json?.natal?.aspects || [];
+            log(`Aspect rows: ${aspects.length}`, aspects.length === 0);
+            const angles = json?.natal?.angles || {};
+            const hasAngles = angles.ASC && angles.MC;
+            log(`Angles ASC/MC present: ${hasAngles}`, !hasAngles);
+            const satMoon = aspects.some(a => (a.a === 'Saturn' && a.b === 'Moon') || (a.a === 'Moon' && a.b === 'Saturn'));
+            log(`Saturn↔Moon present: ${satMoon}`, !satMoon);
+        }
+
+        function toggleRaw(){
+            const pre = document.getElementById('raw-json');
+            pre.style.display = pre.style.display === 'none' ? 'block' : 'none';
         }
 
         async function makeApiCall(data, testName) {
@@ -45,16 +66,22 @@
                     body: JSON.stringify(data)
                 });
 
-                const result = await response.json();
-                
-                if (response.ok) {
-                    log(`✅ ${testName} SUCCESS`, false, true);
-                    log(`Response preview: ${JSON.stringify(result).substring(0, 200)}...`);
-                } else {
-                    log(`❌ ${testName} FAILED: ${result.error}`, true);
-                    if (result.missing) {
-                        log(`Missing fields: ${result.missing.join(', ')}`, true);
+                const text = await response.text();
+                try {
+                    const result = JSON.parse(text);
+                    document.getElementById('raw-json').textContent = JSON.stringify(result, null, 2);
+                    if (response.ok) {
+                        log(`✅ ${testName} SUCCESS`, false, true);
+                        log(`Response preview: ${JSON.stringify(result).substring(0, 200)}...`);
+                        assertBasics(result);
+                    } else {
+                        log(`❌ ${testName} FAILED: ${result.error}`, true);
+                        if (result.missing) {
+                            log(`Missing fields: ${result.missing.join(', ')}`, true);
+                        }
                     }
+                } catch(e){
+                    log(`❌ ${testName} JSON parse error: ${e.message}`, true);
                 }
             } catch (error) {
                 log(`❌ ${testName} ERROR: ${error.message}`, true);


### PR DESCRIPTION
## Summary
- document raw math requirements and expose natal/transit endpoints
- add normalizer and report composer for raw math tables and JSON blocks
- update sample templates and debug pages with raw JSON toggles and assertions

## Testing
- `npm run build:css`
- `npm run verify-copilot`


------
https://chatgpt.com/codex/tasks/task_e_68b9e8443d18832fab2e537d75c1d2ff