### PR TITLE
Include top-level reports in Raven export

### DIFF
--- a/index.html
+++ b/index.html
@@ -6532,9 +6532,11 @@ function renderTransitDay(dateStr, items){
                 // Attach any prebuilt reports/templates if present
                 const reports = {};
                 try {
-                    if (data?.reports?.mirror_report) reports.mirror_report = data.reports.mirror_report;
-                    if (data?.reports?.balance_meter_report) reports.balance_meter_report = data.reports.balance_meter_report;
-                    if (data?.reports?.templates) reports.templates = data.reports.templates;
+                    // Start with any existing reports block
+                    if (data?.reports) Object.assign(reports, data.reports);
+                    // Merge top-level reports if they haven't been nested
+                    if (data?.mirror_report) reports.mirror_report = data.mirror_report;
+                    if (data?.balance_meter_report) reports.balance_meter_report = data.balance_meter_report;
                 } catch(_){}
 
                 return {
@@ -10122,12 +10124,16 @@ function renderTransitDay(dateStr, items){
                 
                 // Store the generated report for tab switching
                 if (report && report.length > 0) {
+                    // Ensure nested reports container exists
+                    latestResultData.reports = latestResultData.reports || {};
                     if (shouldRenderBalance) {
                         // Store Balance Meter report
                         latestResultData.balance_meter_report = report;
+                        latestResultData.reports.balance_meter_report = report;
                     } else {
                         // Store Mirror report
                         latestResultData.mirror_report = report;
+                        latestResultData.reports.mirror_report = report;
                     }
                 }
                 


### PR DESCRIPTION
## Summary
- Merge top-level `mirror_report` and `balance_meter_report` into the `reports` block in `buildRavenJsonReport`
- Store generated reports under `latestResultData.reports` for easier export and tab switching

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfa6122cf0832f91a02ba36ead9f2d