### PR TITLE
feat: exclude templates from raven JSON export

### DIFF
--- a/index.html
+++ b/index.html
@@ -6529,12 +6529,11 @@ function renderTransitDay(dateStr, items){
                     }
                 } catch(e) { /* noop */ }
 
-                // Attach any prebuilt reports/templates if present
+                // Attach any prebuilt reports if present (exclude templates)
                 const reports = {};
                 try {
-                    if (data?.reports?.mirror_report) reports.mirror_report = data.reports.mirror_report;
-                    if (data?.reports?.balance_meter_report) reports.balance_meter_report = data.reports.balance_meter_report;
-                    if (data?.reports?.templates) reports.templates = data.reports.templates;
+                    if (data?.reports && 'mirror_report' in data.reports) reports.mirror_report = data.reports.mirror_report;
+                    if (data?.reports && 'balance_meter_report' in data.reports) reports.balance_meter_report = data.reports.balance_meter_report;
                 } catch(_){}
 
                 return {


### PR DESCRIPTION
## Summary
- prevent `buildRavenJsonReport` from including `reports.templates`
- keep `mirror_report` and `balance_meter_report` if present

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfa610d314832f885260a3192d332c