### PR TITLE
Prevent Netlify builds from treating warnings as errors

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
   Content-Security-Policy = "default-src 'self' blob:; script-src 'self' https://cdn.auth0.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://s.gravatar.com https://cdn.auth0.com; connect-src 'self' ws: wss: https://*.auth0.com; frame-src https://*.auth0.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';"
 
 [build]
-  command = "npm run build"
+  command = "CI='' npm run build"
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
## Summary
- prefix the Netlify build command with `CI=''` so the CI environment does not convert warnings into fatal errors during deploys

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdf975ef3c832fa97a7389493da198