### PR TITLE
Configure Netlify publish directory

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,7 @@
 [build]
   command = "npm run build"
   environment = { CI = "false" }
+  publish = ".next"
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
## Summary
- set the Netlify build configuration to publish the built Next.js assets from the .next directory

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cf3ffa8f58832f91b579a135224bc4