### PR TITLE
Configure Netlify publish directory

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,7 @@
 [build]
   command = "npm run build"
   environment = { CI = "false" }
+  publish = ".next"
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"

--- a/netlify/functions/astrology-health.js
+++ b/netlify/functions/astrology-health.js
@@ -4,7 +4,7 @@
  */
 
 // Import the health function from the main module
-const { health } = require('./astrology-mathbrain');
+const { health } = require('../lib/server/astrology-mathbrain.js');
 
 // Export the health handler
 exports.handler = health;

--- a/netlify/functions/resolve-city.js
+++ b/netlify/functions/resolve-city.js
@@ -2,7 +2,7 @@
 // GET /api/resolve-city?city=Bryn+Mawr&state=PA&nation=US
 // Returns resolved coordinates and timezone to verify what the API sees
 
-const { health, resolveCity } = require('./astrology-mathbrain');
+const { health, resolveCity } = require('../lib/server/astrology-mathbrain.js');
 
 exports.handler = async (event, context) => {
   // Set CORS headers


### PR DESCRIPTION
## Summary
- set the Netlify build configuration to publish the built Next.js assets from the .next directory
- point the astrology health and resolve-city Netlify functions at the shared lib/server/astrology-mathbrain implementation so the bundler can locate their dependency

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cf3ffa8f58832f91b579a135224bc4