### PR TITLE
Normalize auth flag parsing

### DIFF
--- a/components/HomeHero.tsx
+++ b/components/HomeHero.tsx
@@ -18,7 +18,15 @@ declare global {
   }
 }
 
-const authEnabled = process.env.NEXT_PUBLIC_ENABLE_AUTH === 'true';
+const authEnabled = (() => {
+  const raw = process.env.NEXT_PUBLIC_ENABLE_AUTH;
+  if (typeof raw !== "string") return true;
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "" || normalized === "false" || normalized === "0") {
+    return false;
+  }
+  return true;
+})();
 const poeticBrainEnabled = process.env.NEXT_PUBLIC_ENABLE_POETIC_BRAIN === 'true';
 
 export default function HomeHero() {

--- a/components/RequireAuth.tsx
+++ b/components/RequireAuth.tsx
@@ -18,7 +18,15 @@ declare global {
   }
 }
 
-const authEnabled = process.env.NEXT_PUBLIC_ENABLE_AUTH === 'true';
+const authEnabled = (() => {
+  const raw = process.env.NEXT_PUBLIC_ENABLE_AUTH;
+  if (typeof raw !== 'string') return true;
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === '' || normalized === 'false' || normalized === '0') {
+    return false;
+  }
+  return true;
+})();
 
 export default function RequireAuth({ children }: { children: React.ReactNode }) {
   const [ready, setReady] = useState(false);


### PR DESCRIPTION
## Summary
- treat NEXT_PUBLIC_ENABLE_AUTH as enabled unless explicitly set to false, 0, or empty in HomeHero
- reuse the same normalization in RequireAuth to keep routing and UI behavior aligned

## Testing
- npm run build
- NEXT_PUBLIC_ENABLE_AUTH=TRUE npm run build
- NEXT_PUBLIC_ENABLE_AUTH=false npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf5c0cce5c832fb39739bb93abd9ed