### PR TITLE
Calibrate valence output to Balance Meter spec

### DIFF
--- a/Developers Notes/The Four Report Types.md
+++ b/Developers Notes/The Four Report Types.md
@@ -33,6 +33,11 @@ Each report type serves a distinct analytical purpose within the WovenWebApp sys
 - MAP: Structural skeleton showing geometric relationships and behavioral architectures
 - VOICE: Conditional mirror language offering testable insights without deterministic claims
 
+### User Input Flow (Applies to All Reports)
+- Birth credentials are always supplied by the user: legal/preferred name, birth date, birth time, birthplace (city + state or coordinates), and timezone confirmation.
+- Relocation/translocation is an explicit user choice. When the toggle is active the payload includes the chosen lens (`A_local`, `B_local`, `Custom`, etc.) together with either coordinates or a city/nation combination.
+- For internal QA Person A loads with a default A_local lens (Panama City, FL) so testers can submit quickly, but the location can be edited or the lens turned off before sending the request.
+
 ---
 
 ## 1. Solo Mirror Report (Individual Constitutional Analysis)

--- a/The Four Report Types.txt
+++ b/The Four Report Types.txt
@@ -1,5 +1,387 @@
 ﻿Report Types
-Woven Map Report FrameworkCore Components (All Reports)Every report includes these six elements:- Typological Profile: Constitutional climate layer- Balance Meter: Magnitude, valence, volatility metrics- Vector-Integrity Check: Latent vs suppressed influences- Polarity Cards: FIELD → MAP → VOICE progression- Mirror Voice: Reflective narrative that returns agency- Raw Geometry: Mathematical data appendix1. Solo Mirror Report (Individual Chart)Header- Person: Name, birth date/time/location, coordinates, timezone- Mode: Natal | Natal+Transits- Date Range: [if transits included]Core SectionsTypological Profile- Dominant Orientation: Primary function with planetary anchors- Secondary Orientation: Background rhythm, conditional behaviors- Shadow Orientation: Friction points, squares, Saturn/Pluto knots- Constitutional Climate: Metaphor tying all orientations togetherChart Summary- Planetary placements (Sun → Pluto, Nodes, Chiron)- Angles: ASC/MC/DSC/IC- Major aspectsTransit Analysis (if applicable)- Significant transits to natal placements- Transit table for date rangeBalance Meter- Magnitude (0-5): Pressure intensity- Valence (-5 to +5): Supportive vs restrictive- Volatility (0-5): Stability vs chaos- Climate Line: One-sentence weather metaphorVector-Integrity Check- Latent: Constitutional placements not yet activated- Suppressed: Compensated or muted by other structuresPolarity Cards- FIELD: Somatic tone baseline- MAP: Geometric skeleton (angles, polarities)- VOICE: Second-person conditional mirrorMirror Voice- Narrative of amplifications + frictions- Closes with: "What feels most alive to you here?"2. Solo Balance Meter Report (Transit Focus)Header- Person data + transit date rangeCore SectionsBalance Meter Overview- Magnitude, Valence, Volatility scores- Climate Line: Baseline solo weather metaphorTime Series Data- Daily/weekly seismograph bars- Aggregation: mean or max valuesIntegration Factors (Percentages)- Fertile Field %- Harmonic Resonance %- Expansion Lift %- Combustion Clarity %- Liberation/Release %- Integration %Vector-Integrity + Polarity Cards + Mirror Voice- Same structure as Solo Mirror- Focuses on transit pressure patterns- Closes with: "What part feels steady, what part scattered?"3. Relational Mirror Report (Synastry/Composite)Header- Person A + Person B data- Mode: Synastry | Composite | Both- Date Range: [if transits included]Core SectionsIndividual Natal Summaries- Person A: Sun, Moon, Mercury, Venus, Mars, outer planets, angles- Person B: Same structureRelocation Overlay (if applicable)- Mode: None | A_local | B_local | Midpoint- Coordinates and angle/house shiftsAspect Analysis- Intra-Chart: Major aspects within each person's chart- Synastry: Cross-aspects A→B and B→A- Special Flags: Angular hits, anaretic degrees, exact contactsTransit Analysis (if applicable)- Transits to A's chart- Transits to B's chart- Transits to key synastry contactsBalance Meter (Relational)- Magnitude (0-5): Joint pressure size- Valence (-5 to +5): Dyadic supportive vs restrictive tilt- Volatility (0-5): Bond stability vs turbulence- Differential: Where A vs B carries more load- Climate Line: How A's baseline meets B's baselineVector-Integrity Check- Latent Cross-Vectors: Structural but not yet activated- Suppressed Vectors: Muted by compensatory geometryPolarity Cards (Shared)- FIELD: Dyadic somatic tone- MAP: Cross-chart geometric skeleton- VOICE: Non-prescriptive relational mirrorMirror Voice- Where bond amplifies vs where scaffolding falters- Closes with: "Where do you notice support vs drag most?"4. Relational Balance Meter ReportHeader- Both persons' data + transit date rangeCore SectionsIndividual Natal Summaries (Constitutional Anchors)- Person A: Sun, Moon, Mercury, Venus, Mars, outer planets, angles- Person B: Same structure- Key Synastry Contacts: Core cross-aspects for contextRelational Balance Overview- Joint magnitude, valence, volatility- Differential load analysis- Dyadic climate metaphorTime Series Data- Joint seismograph bars- Daily/weekly aggregationSupport Analysis- Support Scaffolding: Present | Challenged | Absent- Resilience: Depleted | Resilient | ReboundingVector-Integrity + Polarity Cards + Mirror Voice- Same relational structure as #3- Focus on transit pressure in the bond- Returns agency to both individualsRaw Geometry Appendix (All Reports)Solo Reports- Natal placements table- Aspect grid- Transit logsRelational Reports- Full synastry aspect tables- Composite chart summary- Transit overlay logsDesign PrinciplesMath Brain Pure: Geometry-first, behavior-language only Balance Meter Integration: Climate diagnostics, not personality readingsNon-Interpretive: Surfaces patterns without prescription Agency-Returning: Always closes by empowering self-reflection Modular: Each component serves a specific diagnostic function
+Woven Map Report Framework
+Core Components (All Reports)
+Every report includes these six elements:
+- Typological Profile: Constitutional climate layer
+- Balance Meter: Magnitude, valence, volatility metrics
+- Vector-Integrity Check: Latent vs suppressed influences
+- Polarity Cards: FIELD → MAP → VOICE progression
+- Mirror Voice: Reflective narrative that returns agency
+- Raw Geometry: Mathematical data appendix
+User Input Baseline (applies to all four reports)
+- Birth data is entered by the user: name, birth date, birth time, and birthplace (city + state or direct coordinates) alongside timezone.
+- Relocation is optional and user-controlled. When the translocation toggle is on, the request includes the active lens (`A_local`, `B_local`, `Custom`, etc.) plus either coordinates or a city/nation pair.
+- Person A’s sandbox defaults to Panama City, FL (A_local) for quick testing, but the location can be edited or the relocation lens can be switched off before submission.
+
+1. Solo Mirror Report (Individual Chart)
+Header
+- Person: Name, birth date/time/location, coordinates, timezone
+- Mode: Natal | Natal+Transits
+- Date Range: [if transits included]
+Core Sections
+Typological Profile
+- Dominant Orientation: Primary function with planetary anchors
+- Secondary Orientation: Background rhythm, conditional behaviors
+- Shadow Orientation: Friction points, squares, Saturn/Pluto knots
+- Constitutional Climate: Metaphor tying all orientations together
+Chart Summary
+- Planetary placements (Sun → Pluto, Nodes, Chiron)
+- Angles: ASC/MC/DSC/IC
+- Major aspects
+Transit Analysis (if applicable)
+- Significant transits to natal placements
+- Transit table for date range
+Balance Meter
+- Magnitude (0-5): Pressure intensity
+- Valence (-5 to +5): Supportive vs restrictive
+- Volatility (0-5): Stability vs chaos
+- Climate Line: One-sentence weather metaphor
+Vector-Integrity Check
+- Latent: Constitutional placements not yet activated
+- Suppressed: Compensated or muted by other structures
+Polarity Cards
+- FIELD: Somatic tone baseline
+- MAP: Geometric skeleton (angles, polarities)
+- VOICE: Second-person conditional mirror
+Mirror Voice
+- Narrative of amplifications + frictions
+- Closes with: "What feels most alive to you here?"
+
+2. Solo Balance Meter Report (Transit Focus)
+Header
+- Person data + transit date range
+Core Sections
+Balance Meter Overview
+- Magnitude, Valence, Volatility scores
+- Climate Line: Baseline solo weather metaphor
+Time Series Data
+- Daily/weekly seismograph bars
+- Aggregation: mean or max values
+Integration Factors (Percentages)
+- Fertile Field %
+- Harmonic Resonance %
+- Expansion Lift %
+- Combustion Clarity %
+- Liberation/Release %
+- Integration %
+Vector-Integrity + Polarity Cards + Mirror Voice
+- Same structure as Solo Mirror
+- Focuses on transit pressure patterns
+- Closes with: "What part feels steady, what part scattered?"
+
+3. Relational Mirror Report (Synastry/Composite)
+Header
+- Person A + Person B data
+- Mode: Synastry | Composite | Both
+- Date Range: [if transits included]
+Core Sections
+Individual Natal Summaries
+- Person A: Sun, Moon, Mercury, Venus, Mars, outer planets, angles
+- Person B: Same structure
+Relocation Overlay (if applicable)
+- Mode: None | A_local | B_local | Midpoint
+- Coordinates and angle/house shifts
+Aspect Analysis
+- Intra-Chart: Major aspects within each person's chart
+- Synastry: Cross-aspects A→B and B→A
+- Special Flags: Angular hits, anaretic degrees, exact contacts
+Transit Analysis (if applicable)
+- Transits to A's chart
+- Transits to B's chart
+- Transits to key synastry contacts
+Balance Meter (Relational)
+- Magnitude (0-5): Joint pressure size
+- Valence (-5 to +5): Dyadic supportive vs restrictive tilt
+- Volatility (0-5): Bond stability vs turbulence
+- Differential: Where A vs B carries more load
+- Climate Line: How A's baseline meets B's baseline
+Vector-Integrity Check
+- Latent Cross-Vectors: Structural but not yet activated
+- Suppressed Vectors: Muted by compensatory geometry
+Polarity Cards (Shared)
+- FIELD: Dyadic somatic tone
+- MAP: Cross-chart geometric skeleton
+- VOICE: Non-prescriptive relational mirror
+Mirror Voice
+- Where bond amplifies vs where scaffolding falters
+- Closes with: "Where do you notice support vs drag most?"
+
+4. Relational Balance Meter Report
+Header
+- Both persons' data + transit date range
+Core Sections
+Individual Natal Summaries (Constitutional Anchors)
+- Person A: Sun, Moon, Mercury, Venus, Mars, outer planets, angles
+- Person B: Same structure
+- Key Synastry Contacts: Core cross-aspects for context
+Relational Balance Overview
+- Joint magnitude, valence, volatility
+- Differential load analysis
+- Dyadic climate metaphor
+Time Series Data
+- Joint seismograph bars
+- Daily/weekly aggregation
+Support Analysis
+- Support Scaffolding: Present | Challenged | Absent
+- Resilience: Depleted | Resilient | Rebounding
+Vector-Integrity + Polarity Cards + Mirror Voice
+- Same relational structure as #3
+- Focus on transit pressure in the bond
+- Returns agency to both individuals
+
+Raw Geometry Appendix (All Reports)
+Solo Reports
+- Natal placements table
+- Aspect grid
+- Transit logs
+Relational Reports
+- Full synastry aspect tables
+- Composite chart summary
+- Transit overlay logs
+
+Design Principles
+Math Brain Pure: Geometry-first, behavior-language only Balance Meter Integration: Climate diagnostics, not personality readings
+Non-Interpretive: Surfaces patterns without prescription Agency-Returning: Always closes by empowering self-reflection Modular: Each component serves a specific diagnostic function
+
+Info Needed
+Woven Map Report Generation Guide
+Required Data Collection
+Solo Report Inputs
+Identity & Birth Data
+- Name: Full name or preferred identifier
+- Birth Date: YYYY-MM-DD format
+- Birth Time: HH:MM (as exact as possible)
+- Birth City & Nation: Full location name
+- Latitude/Longitude: Precise coordinates for birth city
+- Timezone: Local offset or region at time of birth
+- Zodiac Type: Tropical or Sidereal
+Mode & Analysis Window
+- Mode:
+- Natal (constitution only)
+- Natal + Transits (constitution under current weather)
+- If using transits:
+- Start Date: Beginning of analysis period
+- End Date: End of analysis period
+- Step: Daily/Weekly/Monthly intervals
+
+Relational Report Inputs
+Person B Data (same fields as Person A)
+- Name, birth date/time, city/nation, lat/lon, timezone, zodiac type
+Relationship Context (for narrative framing)
+- Type: Partner | Friend/Colleague | Family
+- If Partner: Intimacy Tier (P1–P5a/b)
+- P1: Early/casual/feeling it out
+- P2: Established/regular rhythm
+- P3: Committed routines/shared planning
+- P4: Living together/high interdependence
+- P5a: Formal union (married/common-law)
+- P5b: Post-union complexity (separated/divorcing)
+- If Family: Role (Parent, Offspring, Sibling, etc.)
+- Ex/Estranged: On/Off (available for Partner & Family types)
+- Notes: ≤500 characters of context (e.g., "co-parenting long-distance")
+Analysis Mode
+- Synastry | Synastry + Transits | Composite | Dual Natal + Transits
+- Transit Window (if applicable): Start/End/Step dates
+
+Relocation ("Translocation") Options
+What Relocation Does
+Relocation doesn't move the planets; it reanchors the house system and angles to a different place on Earth. This changes where planetary energies land (houses/ASC/MC) and when certain pressures peak locally.
+When to Consider Relocation
+- You want the chart to reflect where life is actually happening now (not birth city)
+- You're planning or analyzing an event in a specific city
+- Long-distance relationships where neither person lives in their birth city anymore
+Relocation Options
+None
+- Use birth locations as-is
+- Best for constitutional-only reads or when location doesn't matter
+A_local
+- Reanchor to Person A's current city
+- Good when A is the primary focus or context centers on A's life terrain (moves, work, health, home)
+B_local
+- Reanchor to Person B's current city
+- Mirror of A_local; use when action centers on B's experience
+Midpoint
+- Use geographic midpoint between A and B (or chosen neutral city)
+- Fair for remote/long-distance bonds or shared travel planning
+What Changes vs. Stays
+Changes:
+- House cusps and angles (ASC/MC/DSC/IC)
+- Timing emphases for transits hitting angles
+- Local environmental emphasis
+Stays Put:
+- Planetary longitudes (degrees in signs)
+- Aspects between planets
+- Core synastry/composite math
+Rule of Thumb
+Decide the setting of the story (whose city or neutral location) → pick relocation mode → run report. If comparing options, generate quick passes (e.g., None vs A_local) and see which climate line matches lived reality.
+
+Data Impact Guide
+What Affects the Math
+- Birth dates/times
+- Geographic coordinates (lat/lon/timezone)
+- Analysis mode selection
+- Transit date windows
+- Relocation coordinates
+What Affects the Language Only
+- Relationship context (type, intimacy tier, role)
+- Ex/Estranged status
+- Notes field
+- Nothing in relationship context changes underlying geometry—only how it's described
+
+Quality Control Notes
+Birth Time Accuracy
+- Exact time preferred for precise angles and houses
+- If unknown, can approximate (e.g., 12:00 noon), but treat angles/houses and Moon positions as softer data
+- Time accuracy affects house placements and angle-based timing
+Timezone Clarity
+- Use correct local offset/region at time of birth
+- Account for historical timezone changes if birth was decades ago
+- Double-check daylight saving time status for birth date
+Transit Windows
+- Shorter windows (days to weeks): Good for immediate decisions and current conditions
+- Longer windows (months to seasons): Better for seeing larger cycles and patterns
+- Step intervals: Daily for detailed tracking, weekly for general patterns, monthly for broad trends
+Relationship Context Accuracy
+- Choose settings that reflect current reality, not aspirational or past states
+- Update context if relationship status changes significantly
+- Use Notes field for crucial details that affect interpretation (custody arrangements, geographic distance, etc.)
+
+Quick Decision Trees
+Solo Report: Natal vs. Natal+Transits?
+- Natal only: Understanding core constitution, personality patterns, life themes
+- Natal + Transits: Current pressures, timing decisions, what's active now
+Relational Report: Which Mode?
+- Synastry: How you affect each other (individual charts interacting)
+- Composite: The relationship as its own entity (midpoint chart)
+- Dual Natal + Transits: Both individual constitutions under current weather
+- Synastry + Transits: Individual interactions plus current external pressures
+Relocation: None vs. Local?
+- None: Constitutional analysis, personality compatibility, broad patterns
+- Local: Current life circumstances, timing for specific location, practical decisions
+Transit Window: How Long?
+- 1-4 weeks: Immediate decisions, current crisis or opportunity
+- 1-6 months: Seasonal planning, medium-term projects
+- 1+ years: Life phase analysis, major transitions
+
+The Poetic Brain
+Woven Map Feedback Loop System
+The Recognition-to-Refinement Pipeline
+1. Hook Stack (Recognition Gateway)
+What it is: Front-door UX using 2–4 high-charge, dual-polarity titles sourced from tightest aspects
+- Example: "Restless & Thrill-Seeking / Disciplined or Shut Down"
+- Tier-1 Orbs: Tight surgical window to ensure immediate felt recognition
+- Purpose: Bypass analysis, trigger limbic "that's me" ping, open door for depth work
+Process: Math Brain geometry → short, vivid cards (no theory, no advice)
+
+2. Poetic Brain Translation (Core Processing)
+What it is: The translation spine turning weather into usable mirrors
+- Tier-2 Orbs: Slightly wider window to catch full pattern for depth work
+Three-Layer Structure:
+- FIELD: Somatic climate in one sentence (jaw clamp, open chest, tab-overload)
+- MAP: Structural tension named plainly (security ↔ risk, compression → release)
+- VOICE: If/then prompt in small time box ("test X for 3 days; if volatility spikes, halve scope")
+Purpose: Move from feeling → structure → choice without prediction
+
+3. SST Logs (Falsifiability Table)
+What it is: The honesty-keeping system for mirror accuracy
+Three Categories:
+- WB (Within Boundary): Clear, felt resonance; user confirms
+- ABE (At Boundary Edge): Partial/inverted/mis-toned resonance; still useful signal
+- OSR (Outside Symbolic Range): No resonance; valid non-hit
+Purpose: Keep mirrors honest; misses become calibration data, not user error
+
+4. Drift Index (Symbolic Grammar Updates)
+What it is: Sidereal-lean detector built from clarification data
+Process:
+- Classify clarifications (especially OSRs) as:
+- Driver-aligned (sidereal-leaning)
+- Role-aligned (tropical-leaning)
+- If OSR clusters lean Driver, flag Sidereal Drift
+Effect: Future mirrors prioritize Driver language and examples—no chart redraw required
+Purpose: Keep language matched to lived self-perception
+
+5. Session Scores (Transparent Metrics)
+What it is: Non-gamified session performance indicators
+Three Metrics:
+- Accuracy: WB ÷ (WB + ABE + OSR)
+- Edge Capture: ABE ÷ (WB + ABE)
+- Clarity: 1 - (unclear prompts ÷ total prompts)
+Purpose: Show how well mirrors landed, how often they caught the "edge," how clear they read—enabling system tuning
+
+6. Wrap-Up Card (Session Sealer)
+What it is: Single keepsake + checkpoint summary
+Contents:
+- 2–3 strongest Hook Stack titles
+- Actor/Role composite
+- Resonance scorecard (WB/ABE/OSR)
+- Climate line (if timed)
+- Optional Poetic Index
+- Sidereal Drift flag (if present)
+Purpose: Memory anchor + falsifiability snapshot to carry forward
+
+7. Adaptive Loop (Next Session Tuning)
+What it is: How the system evolves based on feedback
+Adaptation Mechanics:
+- Language Weighting: Drift Index influences Driver vs Role emphasis
+- Container Sizing: Balance Meter + scores adjust pacing and detail level
+- Clarity Tuning: Raises or lowers detail based on Clarity scores
+- Boundary Targeting: Edge Capture highlights zones for deeper exploration
+Purpose: Each round gets truer, plainer, and easier to test
+
+Daily Integration Layer
+
+Daily Integration Layer
+Recognition Layer Prompts
+Daily felt tension check-ins:
+- WB Cue: "Where did a card land in your body today (breath, jaw, stomach)?"
+- ABE Cue: "What almost fit—what single word would make it land?"
+- OSR Cue: "What did you not feel at all (real, but situational; not sourced in your chart)?"
+Weight Belt (Shareable Summary)
+Picture: Palms on desk, slow breath, jaw unclenches—before glancing at any dials
+Components:
+- Feeling: Steady grounding
+- Container: Three-day test, one change, no big bets
+- Options: Log one somatic ping first OR run tiny VOICE prompt after naming the feeling
+- Next Step: Write one-line body note NOW, then consult Balance Meter; let presence set tone, weather set pacing
+Key Change: Presence first, weather second—body wisdom leads, metrics follow
+
+System Philosophy
+Falsifiability First
+Every mirror must be testable. Misses are calibration data, not failures.
+Recognition Before Analysis
+Hook Stack bypasses cognitive processing to hit felt sense directly.
+Adaptive Language
+System learns your symbolic grammar and adjusts accordingly.
+Transparent Metrics
+No hidden algorithms—you see exactly how well the mirrors are working.
+Micro-Container Testing
+Small experiments (3-7 days) with measurable outcomes.
+
+Feedback Flow Summary
+1. Hook Stack → Immediate recognition
+2. Poetic Brain → Structured translation
+3. SST Logs → Honesty tracking
+4. Drift Index → Language calibration
+5. Session Scores → Performance metrics
+6. Wrap-Up Card → Session summary
+7. Adaptive Loop → System evolution
+8. Recognition Layer → Daily integration
+9. Next Session → Improved targeting
+Each loop refines the system's ability to generate accurate, useful mirrors while maintaining falsifiability and user agency.
+
+
+
+
+
+
+
+
+
+
+
+
+
+- Vector-Integrity Check: Latent vs suppressed influences- Polarity Cards: FIELD → MAP → VOICE progression- Mirror Voice: Reflective narrative that returns agency- Raw Geometry: Mathematical data appendix1. Solo Mirror Report (Individual Chart)Header- Person: Name, birth date/time/location, coordinates, timezone- Mode: Natal | Natal+Transits- Date Range: [if transits included]Core SectionsTypological Profile- Dominant Orientation: Primary function with planetary anchors- Secondary Orientation: Background rhythm, conditional behaviors- Shadow Orientation: Friction points, squares, Saturn/Pluto knots- Constitutional Climate: Metaphor tying all orientations togetherChart Summary- Planetary placements (Sun → Pluto, Nodes, Chiron)- Angles: ASC/MC/DSC/IC- Major aspectsTransit Analysis (if applicable)- Significant transits to natal placements- Transit table for date rangeBalance Meter- Magnitude (0-5): Pressure intensity- Valence (-5 to +5): Supportive vs restrictive- Volatility (0-5): Stability vs chaos- Climate Line: One-sentence weather metaphorVector-Integrity Check- Latent: Constitutional placements not yet activated- Suppressed: Compensated or muted by other structuresPolarity Cards- FIELD: Somatic tone baseline- MAP: Geometric skeleton (angles, polarities)- VOICE: Second-person conditional mirrorMirror Voice- Narrative of amplifications + frictions- Closes with: "What feels most alive to you here?"2. Solo Balance Meter Report (Transit Focus)Header- Person data + transit date rangeCore SectionsBalance Meter Overview- Magnitude, Valence, Volatility scores- Climate Line: Baseline solo weather metaphorTime Series Data- Daily/weekly seismograph bars- Aggregation: mean or max valuesIntegration Factors (Percentages)- Fertile Field %- Harmonic Resonance %- Expansion Lift %- Combustion Clarity %- Liberation/Release %- Integration %Vector-Integrity + Polarity Cards + Mirror Voice- Same structure as Solo Mirror- Focuses on transit pressure patterns- Closes with: "What part feels steady, what part scattered?"3. Relational Mirror Report (Synastry/Composite)Header- Person A + Person B data- Mode: Synastry | Composite | Both- Date Range: [if transits included]Core SectionsIndividual Natal Summaries- Person A: Sun, Moon, Mercury, Venus, Mars, outer planets, angles- Person B: Same structureRelocation Overlay (if applicable)- Mode: None | A_local | B_local | Midpoint- Coordinates and angle/house shiftsAspect Analysis- Intra-Chart: Major aspects within each person's chart- Synastry: Cross-aspects A→B and B→A- Special Flags: Angular hits, anaretic degrees, exact contactsTransit Analysis (if applicable)- Transits to A's chart- Transits to B's chart- Transits to key synastry contactsBalance Meter (Relational)- Magnitude (0-5): Joint pressure size- Valence (-5 to +5): Dyadic supportive vs restrictive tilt- Volatility (0-5): Bond stability vs turbulence- Differential: Where A vs B carries more load- Climate Line: How A's baseline meets B's baselineVector-Integrity Check- Latent Cross-Vectors: Structural but not yet activated- Suppressed Vectors: Muted by compensatory geometryPolarity Cards (Shared)- FIELD: Dyadic somatic tone- MAP: Cross-chart geometric skeleton- VOICE: Non-prescriptive relational mirrorMirror Voice- Where bond amplifies vs where scaffolding falters- Closes with: "Where do you notice support vs drag most?"4. Relational Balance Meter ReportHeader- Both persons' data + transit date rangeCore SectionsIndividual Natal Summaries (Constitutional Anchors)- Person A: Sun, Moon, Mercury, Venus, Mars, outer planets, angles- Person B: Same structure- Key Synastry Contacts: Core cross-aspects for contextRelational Balance Overview- Joint magnitude, valence, volatility- Differential load analysis- Dyadic climate metaphorTime Series Data- Joint seismograph bars- Daily/weekly aggregationSupport Analysis- Support Scaffolding: Present | Challenged | Absent- Resilience: Depleted | Resilient | ReboundingVector-Integrity + Polarity Cards + Mirror Voice- Same relational structure as #3- Focus on transit pressure in the bond- Returns agency to both individualsRaw Geometry Appendix (All Reports)Solo Reports- Natal placements table- Aspect grid- Transit logsRelational Reports- Full synastry aspect tables- Composite chart summary- Transit overlay logsDesign PrinciplesMath Brain Pure: Geometry-first, behavior-language only Balance Meter Integration: Climate diagnostics, not personality readingsNon-Interpretive: Surfaces patterns without prescription Agency-Returning: Always closes by empowering self-reflection Modular: Each component serves a specific diagnostic function
 Info Needed
 Woven Map Report Generation GuideRequired Data CollectionSolo Report InputsIdentity & Birth Data- Name: Full name or preferred identifier- Birth Date: YYYY-MM-DD format- Birth Time: HH:MM (as exact as possible)- Birth City & Nation: Full location name- Latitude/Longitude: Precise coordinates for birth city- Timezone: Local offset or region at time of birth- Zodiac Type: Tropical or SiderealMode & Analysis Window- Mode:- Natal (constitution only)- Natal + Transits (constitution under current weather)- If using transits:- Start Date: Beginning of analysis period- End Date: End of analysis period- Step: Daily/Weekly/Monthly intervalsRelational Report InputsPerson B Data (same fields as Person A)- Name, birth date/time, city/nation, lat/lon, timezone, zodiac typeRelationship Context (for narrative framing)- Type: Partner | Friend/Colleague | Family- If Partner: Intimacy Tier (P1–P5a/b)- P1: Early/casual/feeling it out- P2: Established/regular rhythm- P3: Committed routines/shared planning- P4: Living together/high interdependence- P5a: Formal union (married/common-law)- P5b: Post-union complexity (separated/divorcing)- If Family: Role (Parent, Offspring, Sibling, etc.)- Ex/Estranged: On/Off (available for Partner & Family types)- Notes: ≤500 characters of context (e.g., "co-parenting long-distance")Analysis Mode- Synastry | Synastry + Transits | Composite | Dual Natal + Transits- Transit Window (if applicable): Start/End/Step datesRelocation ("Translocation") OptionsWhat Relocation DoesRelocation doesn't move the planets; it reanchors the house system and angles to a different place on Earth. This changes where planetary energies land (houses/ASC/MC) and when certain pressures peak locally.When to Consider Relocation- You want the chart to reflect where life is actually happening now (not birth city)- You're planning or analyzing an event in a specific city- Long-distance relationships where neither person lives in their birth city anymoreRelocation OptionsNone- Use birth locations as-is- Best for constitutional-only reads or when location doesn't matterA_local- Reanchor to Person A's current city- Good when A is the primary focus or context centers on A's life terrain (moves, work, health, home)B_local- Reanchor to Person B's current city- Mirror of A_local; use when action centers on B's experienceMidpoint- Use geographic midpoint between A and B (or chosen neutral city)- Fair for remote/long-distance bonds or shared travel planningWhat Changes vs. StaysChanges:- House cusps and angles (ASC/MC/DSC/IC)- Timing emphases for transits hitting angles- Local environmental emphasisStays Put:- Planetary longitudes (degrees in signs)- Aspects between planets- Core synastry/composite mathRule of ThumbDecide the setting of the story (whose city or neutral location) → pick relocation mode → run report. If comparing options, generate quick passes (e.g., None vs A_local) and see which climate line matches lived reality.Data Impact GuideWhat Affects the Math- Birth dates/times- Geographic coordinates (lat/lon/timezone)- Analysis mode selection- Transit date windows- Relocation coordinatesWhat Affects the Language Only- Relationship context (type, intimacy tier, role)- Ex/Estranged status- Notes field- Nothing in relationship context changes underlying geometry—only how it's describedQuality Control NotesBirth Time Accuracy- Exact time preferred for precise angles and houses- If unknown, can approximate (e.g., 12:00 noon), but treat angles/houses and Moon positions as softer data- Time accuracy affects house placements and angle-based timingTimezone Clarity- Use correct local offset/region at time of birth- Account for historical timezone changes if birth was decades ago- Double-check daylight saving time status for birth dateTransit Windows- Shorter windows (days to weeks): Good for immediate decisions and current conditions- Longer windows (months to seasons): Better for seeing larger cycles and patterns- Step intervals: Daily for detailed tracking, weekly for general patterns, monthly for broad trendsRelationship Context Accuracy- Choose settings that reflect current reality, not aspirational or past states- Update context if relationship status changes significantly- Use Notes field for crucial details that affect interpretation (custody arrangements, geographic distance, etc.)Quick Decision TreesSolo Report: Natal vs. Natal+Transits?- Natal only: Understanding core constitution, personality patterns, life themes- Natal + Transits: Current pressures, timing decisions, what's active nowRelational Report: Which Mode?- Synastry: How you affect each other (individual charts interacting)- Composite: The relationship as its own entity (midpoint chart)- Dual Natal + Transits: Both individual constitutions under current weather- Synastry + Transits: Individual interactions plus current external pressuresRelocation: None vs. Local?- None: Constitutional analysis, personality compatibility, broad patterns- Local: Current life circumstances, timing for specific location, practical decisionsTransit Window: How Long?- 1-4 weeks: Immediate decisions, current crisis or opportunity- 1-6 months: Seasonal planning, medium-term projects- 1+ years: Life phase analysis, major transitions
 The Poetic Brain

--- a/lib/server/astrology-mathbrain.js
+++ b/lib/server/astrology-mathbrain.js
@@ -90,7 +90,57 @@ function normalizeTimezone(tz) {
     'AKDT': 'America/Anchorage',
     'HST': 'Pacific/Honolulu'
   };
-  return map[t] || t;
+  const mapped = map[t] || t;
+  try {
+    return new Intl.DateTimeFormat('en-US', { timeZone: mapped }).resolvedOptions().timeZone;
+  } catch {
+    return mapped;
+  }
+}
+
+function normalizeRelocationMode(mode) {
+  if (!mode && mode !== 0) return null;
+  const token = String(mode).trim();
+  if (!token) return null;
+  const lower = token.toLowerCase();
+  if (['none', 'off', 'natal', 'default'].includes(lower)) return 'none';
+  if (['a_local', 'a-local', 'alocal', 'person_a', 'person-a'].includes(lower)) return 'A_local';
+  if (['b_local', 'b-local', 'blocal', 'person_b', 'person-b'].includes(lower)) return 'B_local';
+  if (['custom', 'manual', 'user'].includes(lower)) return 'Custom';
+  if (['midpoint', 'mid-point'].includes(lower)) return 'Midpoint';
+  return token;
+}
+
+function evaluateMirrorReadiness(result) {
+  if (!result || typeof result !== 'object') return false;
+  const wm = result.woven_map;
+  if (!wm || typeof wm !== 'object') return false;
+
+  const voice = wm.mirror_voice;
+  const hasVoice = typeof voice === 'string'
+    ? voice.trim().length > 0
+    : (voice && typeof voice === 'object' && Object.keys(voice).length > 0);
+
+  const vector = wm.vector_integrity || {};
+  const vectorReady = Boolean(
+    vector &&
+    vector.method &&
+    vector.method !== 'stub-0' &&
+    ((Array.isArray(vector.latent) && vector.latent.length > 0) ||
+     (Array.isArray(vector.suppressed) && vector.suppressed.length > 0))
+  );
+
+  const anchorsReady = Boolean(
+    wm.natal_summary &&
+    wm.natal_summary.anchors &&
+    Object.values(wm.natal_summary.anchors).some(Boolean)
+  );
+
+  const sfdReady = wm.balance_meter && wm.balance_meter.support_friction &&
+    wm.balance_meter.support_friction.value !== null &&
+    wm.balance_meter.support_friction.value !== undefined;
+
+  return Boolean(hasVoice && vectorReady && anchorsReady && sfdReady);
 }
 
 // Derive time provenance for a subject based on presence of hour/minute
@@ -1149,6 +1199,8 @@ function calculateSeismograph(transitsByDate, retroFlagsByDate = {}) {
   const daily = {};
   const rollingMagnitudes = []; // Track for 14-day rolling window
   const valenceHistory = []; // Track for trend analysis
+  const rawValenceSeries = [];
+  const calibratedValenceSeries = [];
 
   for (let i = 0; i < days.length; i++) {
     const d = days[i];
@@ -1187,7 +1239,8 @@ function calculateSeismograph(transitsByDate, retroFlagsByDate = {}) {
     // Prepare rolling context for magnitude normalization
     const rollingContext = rollingMagnitudes.length >= 1 ? { magnitudes: [...rollingMagnitudes] } : null;
     
-  const agg = aggregate(aspectsForAggregate, prev, { rollingContext });
+    const agg = aggregate(aspectsForAggregate, prev, { rollingContext });
+    rawValenceSeries.push(agg.valence);
 
   // Determine scaling strategy and confidence
   let scalingStrategy = 'prior';
@@ -1235,14 +1288,17 @@ function calculateSeismograph(transitsByDate, retroFlagsByDate = {}) {
     }));
 
     const dayEntry = {
-      seismograph: { 
-        magnitude: agg.magnitude, 
-        valence: agg.valence, 
+      seismograph: {
+        magnitude: agg.magnitude,
+        valence: agg.valence,
         volatility: dispersionVol, // use dispersion measure
         rawMagnitude: agg.rawMagnitude,
         originalMagnitude: agg.originalMagnitude,
         scaling_strategy: scalingStrategy,
-        scaling_confidence: +scaleConfidence.toFixed(2)
+        scaling_confidence: +scaleConfidence.toFixed(2),
+        valence_calibrated: null,
+        valence_range: [-5, 5],
+        valence_version: null
       },
       aspects: rawDayAspects,
       filtered_aspects: enrichedWithRetrograde,
@@ -1260,7 +1316,12 @@ function calculateSeismograph(transitsByDate, retroFlagsByDate = {}) {
     try {
       const balanceVal = computeBalanceValence(enriched.filtered);
       const { SFD, Splus, Sminus } = computeSFD(enriched.filtered);
-      dayEntry.balance = { magnitude: agg.magnitude, valence: balanceVal, version: 'v1.1' };
+      if (Number.isFinite(balanceVal)) {
+        calibratedValenceSeries.push(balanceVal);
+        dayEntry.seismograph.valence_calibrated = balanceVal;
+        dayEntry.seismograph.valence_version = 'v1.1';
+      }
+      dayEntry.balance = { magnitude: agg.magnitude, valence: balanceVal, version: 'v1.1', range: [-5, 5] };
       dayEntry.sfd = { sfd: SFD, sPlus: Splus, sMinus: Sminus, version: 'v1.2' };
     } catch (e) {
       logger.warn('Balance/SFD computation failed for day', d, e.message);
@@ -1273,9 +1334,23 @@ function calculateSeismograph(transitsByDate, retroFlagsByDate = {}) {
 
   const numDays = days.length;
   const X = Object.values(daily).reduce((s, d) => s + d.seismograph.magnitude, 0) / numDays;
-  const Y = Object.values(daily).reduce((s, d) => s + d.seismograph.valence, 0) / numDays;
   const VI = Object.values(daily).reduce((s, d) => s + d.seismograph.volatility, 0) / numDays;
-  const summary = { magnitude: +X.toFixed(2), valence: +Y.toFixed(2), volatility: +VI.toFixed(2) };
+  const rawAvg = rawValenceSeries.length ? rawValenceSeries.reduce((sum, val) => sum + val, 0) / rawValenceSeries.length : 0;
+  const calibratedAvgBase = calibratedValenceSeries.length
+    ? calibratedValenceSeries.reduce((sum, val) => sum + val, 0) / calibratedValenceSeries.length
+    : rawAvg;
+  const calibratedAvg = Math.max(-5, Math.min(5, calibratedAvgBase));
+  const summary = {
+    magnitude: +X.toFixed(2),
+    valence: +calibratedAvg.toFixed(2),
+    valence_raw: +rawAvg.toFixed(2),
+    valence_version: calibratedValenceSeries.length ? 'v1.1' : 'raw-clamped',
+    valence_range: [-5, 5],
+    volatility: +VI.toFixed(2)
+  };
+  if (calibratedValenceSeries.length) {
+    summary.valence_sample_size = calibratedValenceSeries.length;
+  }
 
   return { daily, summary };
 }
@@ -2014,20 +2089,20 @@ exports.handler = async function(event) {
     const transitA_raw = body.transit_subject || personA;
     const transitB_raw = body.transit_subject_B || body.second_transit_subject || personB;
 
-    // Relocation mode (data-only intent)
-  let relocationMode = (body.relocation_mode || body.translocation?.method || 'None');
-    if (/^midpoint$/i.test(relocationMode)) {
-      return { statusCode: 400, body: JSON.stringify({ code:'RELOCATION_UNSUPPORTED', error:'Midpoint relocation is not supported for this protocol. Use A_local or B_local.', errorId: generateErrorId() }) };
+    const translocationBlock = body.translocation || body.context?.translocation || null;
+    const aLocal = body.personA?.A_local || body.subjectA?.A_local || body.A_local || null;
+    const fallbackModeToken = normalizeRelocationMode(
+      body.relocation_mode || body.context?.relocation_mode || translocationBlock?.method
+    );
+    const relocationRequested = !!(translocationBlock && translocationBlock.applies);
+    let relocationMode = 'none';
+    if (relocationRequested) {
+      relocationMode = normalizeRelocationMode(translocationBlock.method) || (fallbackModeToken && fallbackModeToken !== 'none' ? fallbackModeToken : 'Custom');
+    } else if (fallbackModeToken && fallbackModeToken !== 'none') {
+      relocationMode = fallbackModeToken;
     }
-
-    // Default relocation intent
-    // - Dyad + Balance Meter: default to A_local unless explicitly overridden
-    // - Solo with A_local present: default to A_local
-    const hasDyad = !!(personB && Object.keys(personB).length);
-    const aLocal = body.personA?.A_local || body.subjectA?.A_local || null;
-    if ((relocationMode === 'None' || relocationMode === 'Natal') && wantBalanceMeter) {
-      if (hasDyad) relocationMode = 'A_local';
-      else if (aLocal) relocationMode = 'A_local';
+    if (relocationMode === 'Midpoint') {
+      return { statusCode: 400, body: JSON.stringify({ code:'RELOCATION_UNSUPPORTED', error:'Midpoint relocation is not supported for this protocol. Use A_local or B_local.', errorId: generateErrorId() }) };
     }
 
     if (wantBalanceMeter) {
@@ -2055,6 +2130,9 @@ exports.handler = async function(event) {
     let transitB = transitB_raw ? { ...transitB_raw } : (natalB ? { ...natalB } : null);
 
     // Apply relocation modes
+    let relocationCoords = null;
+    let relocationLabel = translocationBlock?.current_location || (aLocal?.label ?? null);
+
     if (relocationMode === 'Midpoint' && transitB) {
       if (typeof transitA.latitude !== 'number' || typeof transitA.longitude !== 'number' || typeof transitB.latitude !== 'number' || typeof transitB.longitude !== 'number') {
         return { statusCode: 400, body: JSON.stringify({ code:'LOCATION_REQUIRED', error:'Midpoint relocation requires coords for both persons', errorId: generateErrorId() }) };
@@ -2071,26 +2149,51 @@ exports.handler = async function(event) {
         const tz = require('tz-lookup')(mid.latitude, mid.longitude);
         transitA = { ...transitA, latitude: mid.latitude, longitude: mid.longitude, timezone: tz };
         transitB = transitB ? { ...transitB, latitude: mid.latitude, longitude: mid.longitude, timezone: tz } : transitB;
+        relocationCoords = { lat: mid.latitude, lon: mid.longitude, tz };
       } catch {
         return { statusCode: 422, body: JSON.stringify({ code:'HOUSES_UNSTABLE', error:'Midpoint timezone lookup failed; try custom location', errorId: generateErrorId() }) };
       }
     } else if (relocationMode === 'A_local') {
       // Render as-if at A's local venue (and mirror onto B if present)
-      const loc = aLocal || body.custom_location || null;
-      if (loc) {
-        if (typeof loc.lat === 'number' && typeof loc.lon === 'number') {
-          try {
-            const tz = loc.tz || require('tz-lookup')(loc.lat, loc.lon);
-            transitA = { ...transitA, latitude: loc.lat, longitude: loc.lon, timezone: tz };
-            if (transitB) transitB = { ...transitB, latitude: loc.lat, longitude: loc.lon, timezone: tz };
-          } catch {
-            return { statusCode: 400, body: JSON.stringify({ code:'TZ_LOOKUP_FAIL', error:'Could not resolve A_local timezone', errorId: generateErrorId() }) };
-          }
-        } else if (loc.city && loc.nation) {
-          // City-based A_local: rely on transit_subject city/nation; do not inject coords
-          transitA = { ...transitA, city: loc.city, nation: loc.nation };
-          if (transitB) transitB = { ...transitB, city: loc.city, nation: loc.nation };
+      const loc = (() => {
+        if (translocationBlock?.coords && typeof translocationBlock.coords.latitude === 'number' && typeof translocationBlock.coords.longitude === 'number') {
+          return { lat: Number(translocationBlock.coords.latitude), lon: Number(translocationBlock.coords.longitude), tz: translocationBlock.tz };
         }
+        if (typeof translocationBlock?.latitude === 'number' && typeof translocationBlock?.longitude === 'number') {
+          return { lat: Number(translocationBlock.latitude), lon: Number(translocationBlock.longitude), tz: translocationBlock.tz };
+        }
+        if (aLocal) {
+          if (typeof aLocal.lat === 'number' && typeof aLocal.lon === 'number') {
+            return { lat: Number(aLocal.lat), lon: Number(aLocal.lon), tz: aLocal.tz || aLocal.timezone };
+          }
+          if (typeof aLocal.latitude === 'number' && typeof aLocal.longitude === 'number') {
+            return { lat: Number(aLocal.latitude), lon: Number(aLocal.longitude), tz: aLocal.timezone || aLocal.tz };
+          }
+        }
+        if (body.custom_location && typeof body.custom_location.latitude === 'number' && typeof body.custom_location.longitude === 'number') {
+          return { lat: Number(body.custom_location.latitude), lon: Number(body.custom_location.longitude), tz: body.custom_location.timezone };
+        }
+        return null;
+      })();
+
+      if (loc && Number.isFinite(loc.lat) && Number.isFinite(loc.lon)) {
+        try {
+          const tzRaw = loc.tz || translocationBlock?.tz;
+          const tz = tzRaw ? normalizeTimezone(tzRaw) : require('tz-lookup')(loc.lat, loc.lon);
+          transitA = { ...transitA, latitude: loc.lat, longitude: loc.lon, timezone: tz };
+          if (transitB) transitB = { ...transitB, latitude: loc.lat, longitude: loc.lon, timezone: tz };
+          relocationCoords = { lat: loc.lat, lon: loc.lon, tz };
+          if (!relocationLabel) {
+            if (translocationBlock?.current_location) relocationLabel = translocationBlock.current_location;
+            else if (aLocal?.city && aLocal?.nation) relocationLabel = `${aLocal.city}, ${aLocal.nation}`;
+          }
+        } catch {
+          return { statusCode: 400, body: JSON.stringify({ code:'TZ_LOOKUP_FAIL', error:'Could not resolve A_local timezone', errorId: generateErrorId() }) };
+        }
+      } else if (aLocal?.city && aLocal?.nation) {
+        transitA = { ...transitA, city: aLocal.city, nation: aLocal.nation };
+        if (transitB) transitB = { ...transitB, city: aLocal.city, nation: aLocal.nation };
+        if (!relocationLabel) relocationLabel = `${aLocal.city}, ${aLocal.nation}`;
       }
     } else if (relocationMode === 'B_local') {
       if (natalB && transitB && hasLoc(transitB)) {
@@ -2104,9 +2207,12 @@ exports.handler = async function(event) {
         return { statusCode: 400, body: JSON.stringify({ code:'LOCATION_REQUIRED', error:'Custom relocation requires coords', errorId: generateErrorId() }) };
       }
       try {
-        const tz = c.timezone || require('tz-lookup')(c.latitude, c.longitude);
+        const tzRaw = c.timezone || translocationBlock?.tz;
+        const tz = tzRaw ? normalizeTimezone(tzRaw) : require('tz-lookup')(c.latitude, c.longitude);
         transitA = { ...transitA, latitude: c.latitude, longitude: c.longitude, timezone: tz };
         if (transitB) transitB = { ...transitB, latitude: c.latitude, longitude: c.longitude, timezone: tz };
+        relocationCoords = { lat: c.latitude, lon: c.longitude, tz };
+        if (!relocationLabel) relocationLabel = c.label || null;
       } catch {
         return { statusCode: 400, body: JSON.stringify({ code:'TZ_LOOKUP_FAIL', error:'Could not resolve custom timezone', errorId: generateErrorId() }) };
       }
@@ -2143,13 +2249,13 @@ exports.handler = async function(event) {
 
   // timePolicy is already determined earlier to allow fallback time before validation
 
-  const result = { 
-      schema: 'WM-Chart-1.2', 
+  const result = {
+      schema: 'WM-Chart-1.2',
       provenance: {
         math_brain_version: MATH_BRAIN_VERSION,
         ephemeris_source: EPHEMERIS_SOURCE,
         build_ts: new Date().toISOString(),
-        timezone: personA.timezone || 'UTC',
+        timezone: normalizeTimezone(transitA?.timezone || personA.timezone || 'UTC'),
         calibration_boundary: CALIBRATION_BOUNDARY,
         engine_versions: { seismograph: 'v1.0', balance: 'v1.1', sfd: 'v1.2' },
         time_meta_a: deriveTimeMetaWithPolicy(personAOriginal, timePolicy),
@@ -2160,7 +2266,7 @@ exports.handler = async function(event) {
         relocation_mode: relocationMode || 'none'
       },
       context: { mode: modeToken || 'UNKNOWN' },
-      mirror_ready: true,
+      mirror_ready: false,
       contract: 'clear-mirror/1.2',
       person_a: { details: personAOriginal, meta: deriveTimeMetaWithPolicy(personAOriginal, timePolicy) }
     };
@@ -2176,13 +2282,35 @@ exports.handler = async function(event) {
     // Attach translocation (relocation) context from request if provided (data-only)
     try {
       const tl = body.translocation || body.context?.translocation || null;
-      if (tl) {
-        result.context.translocation = {
-          applies: !!tl.applies,
-          method: tl.method || (tl.applies ? 'custom' : 'Natal'),
-          house_system: tl.house_system || 'Placidus',
-          tz: tl.tz || (personA.timezone || 'UTC')
+      if (tl || relocationMode !== 'none') {
+        const ctxApplies = relocationMode !== 'none' ? true : !!tl?.applies;
+        const ctxMethod = relocationMode !== 'none'
+          ? relocationMode
+          : (normalizeRelocationMode(tl?.method) || (ctxApplies ? 'Custom' : 'Natal'));
+        const tzSource = tl?.tz || relocationCoords?.tz || transitA?.timezone || personA.timezone || 'UTC';
+        const coordsBlock = (() => {
+          if (tl?.coords && typeof tl.coords.latitude === 'number' && typeof tl.coords.longitude === 'number') {
+            return { latitude: Number(tl.coords.latitude), longitude: Number(tl.coords.longitude) };
+          }
+          if (typeof tl?.latitude === 'number' && typeof tl?.longitude === 'number') {
+            return { latitude: Number(tl.latitude), longitude: Number(tl.longitude) };
+          }
+          if (relocationCoords) {
+            return { latitude: Number(relocationCoords.lat), longitude: Number(relocationCoords.lon) };
+          }
+          return undefined;
+        })();
+        const currentLocation = tl?.current_location || relocationLabel || (aLocal?.city && aLocal?.nation ? `${aLocal.city}, ${aLocal.nation}` : undefined);
+        const houseSystem = tl?.house_system || 'Placidus';
+        const ctx = {
+          applies: ctxApplies,
+          method: ctxMethod,
+          house_system: houseSystem,
+          tz: normalizeTimezone(tzSource)
         };
+        if (currentLocation) ctx.current_location = currentLocation;
+        if (coordsBlock) ctx.coords = coordsBlock;
+        result.context.translocation = ctx;
       }
     } catch { /* ignore */ }
 
@@ -2796,21 +2924,19 @@ exports.handler = async function(event) {
     }
     // Attach relocation coordinates when applied
     try {
-      if (relocationMode === 'A_local') {
-        const loc = aLocal || body.custom_location || null;
-        if (loc && typeof loc.lat === 'number' && typeof loc.lon === 'number') {
-          const tz = loc.tz || (transitA?.timezone) || null;
-          result.provenance.relocation_coords = { lat: loc.lat, lon: loc.lon, tz };
-        }
-      } else if (relocationMode === 'Midpoint') {
-        if (typeof transitA?.latitude === 'number' && typeof transitA?.longitude === 'number' && transitA?.timezone) {
-          result.provenance.relocation_coords = { lat: transitA.latitude, lon: transitA.longitude, tz: transitA.timezone };
-        }
-      } else if (relocationMode === 'Custom') {
-        const c = body.custom_location;
-        if (c && typeof c.latitude === 'number' && typeof c.longitude === 'number') {
-          result.provenance.relocation_coords = { lat: c.latitude, lon: c.longitude, tz: transitA?.timezone || c.timezone || null };
-        }
+      if (relocationCoords && relocationMode !== 'none') {
+        const tz = relocationCoords.tz ? normalizeTimezone(relocationCoords.tz) : null;
+        result.provenance.relocation_coords = {
+          lat: Number(relocationCoords.lat),
+          lon: Number(relocationCoords.lon),
+          tz
+        };
+      } else if (relocationMode === 'A_local' && aLocal?.city && aLocal?.nation) {
+        result.provenance.relocation_coords = {
+          city: aLocal.city,
+          nation: aLocal.nation,
+          tz: transitA?.timezone ? normalizeTimezone(transitA.timezone) : null
+        };
       }
     } catch { /* ignore */ }
 
@@ -2830,6 +2956,8 @@ exports.handler = async function(event) {
     } catch (e) {
       logger.warn('Woven Map composer failed:', e.message);
     }
+
+    result.mirror_ready = evaluateMirrorReadiness(result);
 
     const safeResult = scrubNarrativeKeys(result);
     return { statusCode: 200, body: JSON.stringify(safeResult) };

--- a/src/reporters/woven-map-composer.js
+++ b/src/reporters/woven-map-composer.js
@@ -11,10 +11,163 @@ function safeNum(x, def = null) {
 
 function clamp(v, min, max) { return Math.max(min, Math.min(max, v)); }
 
-function computeIntegrationFactors(summary) {
+const CORE_PLANETS = new Set([
+  'Sun','Moon','Mercury','Venus','Mars','Jupiter','Saturn','Uranus','Neptune','Pluto'
+]);
+
+const SECONDARY_POINTS = new Set([
+  'Chiron','Mean_Node','True_Node','Mean_South_Node','True_South_Node','Mean_Lilith'
+]);
+
+const ANGLE_POINTS = new Set(['Ascendant','Medium_Coeli','Descendant','Imum_Coeli']);
+
+const VALENCE_BANDS = [
+  { min: -5, max: -4.5, emoji: '🌋', label: 'Pressure / Eruption', polarity: 'negative' },
+  { min: -4.5, max: -3.5, emoji: '⚔', label: 'Friction Clash', polarity: 'negative' },
+  { min: -3.5, max: -2.5, emoji: '🌊', label: 'Cross Current', polarity: 'negative' },
+  { min: -2.5, max: -1.5, emoji: '🌀', label: 'Fog / Dissolution', polarity: 'negative' },
+  { min: -1.5, max: -0.8, emoji: '🌫', label: 'Entropy Drift', polarity: 'negative' },
+  { min: -0.8, max: -0.2, emoji: '🕰', label: 'Saturn Weight', polarity: 'negative' },
+  { min: -0.2, max: 0.2, emoji: '⚖', label: 'Neutral Balance', polarity: 'neutral' },
+  { min: 0.2, max: 0.8, emoji: '🌱', label: 'Fertile Field', polarity: 'positive' },
+  { min: 0.8, max: 1.5, emoji: '🌊', label: 'Flow Tide', polarity: 'positive' },
+  { min: 1.5, max: 2.5, emoji: '✨', label: 'Harmonic Resonance', polarity: 'positive' },
+  { min: 2.5, max: 3.5, emoji: '🔥', label: 'Combustion Clarity', polarity: 'positive' },
+  { min: 3.5, max: 4.5, emoji: '🦋', label: 'Liberation / Release', polarity: 'positive' },
+  { min: 4.5, max: 5.01, emoji: '💎', label: 'Expansion Lift', polarity: 'positive' }
+];
+
+const MAGNITUDE_TERMS = [
+  { max: 0.5, label: 'Whisper' },
+  { max: 1.5, label: 'Pulse' },
+  { max: 2.5, label: 'Wave' },
+  { max: 3.5, label: 'Surge' },
+  { max: 4.5, label: 'Peak' },
+  { max: Infinity, label: 'Apex' }
+];
+
+const VOLATILITY_TERMS = [
+  { max: 0.5, label: 'Aligned Flow', emoji: '➿' },
+  { max: 2, label: 'Cycled Pull', emoji: '🔄' },
+  { max: 3, label: 'Mixed Paths', emoji: '🔀' },
+  { max: 5, label: 'Fragment Scatter', emoji: '🧩' },
+  { max: Infinity, label: 'Vortex Dispersion', emoji: '🌀' }
+];
+
+function classifyMagnitude(value) {
+  const mag = safeNum(value, null);
+  if (mag == null) return null;
+  const entry = MAGNITUDE_TERMS.find(b => mag <= b.max);
+  return entry ? { value: +mag.toFixed(2), term: entry.label } : { value: +mag.toFixed(2), term: null };
+}
+
+function classifyVolatility(value) {
+  const vol = safeNum(value, null);
+  if (vol == null) return null;
+  const entry = VOLATILITY_TERMS.find(b => vol <= b.max);
+  return entry ? { value: +vol.toFixed(2), term: entry.label, emoji: entry.emoji } : { value: +vol.toFixed(2), term: null };
+}
+
+function classifyValence(value) {
+  const val = safeNum(value, null);
+  if (val == null) return null;
+  const clamped = clamp(val, -5, 5);
+  const entry = VALENCE_BANDS.find(b => clamped >= b.min && clamped < b.max);
+  if (!entry) {
+    return { value: +clamped.toFixed(2), term: null, emoji: null, polarity: clamped >= 0 ? 'positive' : 'negative', range: null };
+  }
+  return {
+    value: +clamped.toFixed(2),
+    term: entry.label,
+    emoji: entry.emoji,
+    polarity: entry.polarity,
+    range: [entry.min, entry.max]
+  };
+}
+
+function verdictFromSfd(value) {
+  const sfd = safeNum(value, null);
+  if (sfd == null) return null;
+  if (sfd >= 1) return 'stabilizers prevail';
+  if (sfd <= -1) return 'stabilizers cut';
+  return 'stabilizers mixed';
+}
+
+function normalizeHouseNumber(house) {
+  if (house == null) return null;
+  if (typeof house === 'number' && Number.isFinite(house)) return house;
+  if (typeof house === 'string') {
+    const match = house.match(/(\d{1,2})/);
+    if (match) return Number(match[1]);
+  }
+  return null;
+}
+
+function toAnchorRecord(source) {
+  if (!source || typeof source !== 'object') return null;
+  const degree = source.position ?? source.abs_pos ?? source.degree;
+  const houseRaw = source.house ?? source.house_number ?? source.house_num ?? source.houseLabel;
+  const house = normalizeHouseNumber(houseRaw);
+  const base = {
+    name: source.name || source.axis || null,
+    sign: source.sign || null,
+    element: source.element || null,
+    quality: source.quality || null,
+    degree: degree != null ? +Number(degree).toFixed(2) : null,
+    house,
+    house_label: typeof houseRaw === 'string' ? houseRaw : null
+  };
+  if (source.retrograde !== undefined) base.retrograde = !!source.retrograde;
+  return base;
+}
+
+function findPlacement(placements, name) {
+  if (!Array.isArray(placements)) return null;
+  return placements.find(p => p && p.name === name) || null;
+}
+
+function findAngleEntry(angles, name) {
+  if (!angles) return null;
+  if (Array.isArray(angles)) {
+    return angles.find(a => (a?.name === name) || (a?.axis && a.axis.toLowerCase() === name.toLowerCase())) || null;
+  }
+  if (typeof angles === 'object') {
+    const direct = angles[name];
+    if (direct) return direct;
+    const key = Object.keys(angles).find(k => k.toLowerCase() === name.toLowerCase());
+    return key ? angles[key] : null;
+  }
+  return null;
+}
+
+function buildAnchors(placements, angles) {
+  const sun = toAnchorRecord(findPlacement(placements, 'Sun'));
+  const moon = toAnchorRecord(findPlacement(placements, 'Moon'));
+  const asc = toAnchorRecord(findPlacement(placements, 'Ascendant') || findAngleEntry(angles, 'Ascendant'));
+  const mc = toAnchorRecord(findPlacement(placements, 'Medium_Coeli') || findAngleEntry(angles, 'Medium_Coeli'));
+  return { sun, moon, ascendant: asc, midheaven: mc };
+}
+
+function splitPlacements(list) {
+  if (!Array.isArray(list)) return { core: [], supporting: [], derived: [], raw: null };
+  const core = [];
+  const supporting = [];
+  const derived = [];
+  for (const item of list) {
+    const name = item?.name;
+    if (!name) continue;
+    if (CORE_PLANETS.has(name)) core.push(item);
+    else if (SECONDARY_POINTS.has(name)) derived.push(item);
+    else if (ANGLE_POINTS.has(name)) supporting.push(item);
+    else supporting.push(item);
+  }
+  return { core, supporting, derived, raw: list };
+}
+
+function computeIntegrationFactors(summary, valenceOverride = null) {
   if (!summary) return null;
   const mag = safeNum(summary.magnitude, 0) || 0;
-  const val = safeNum(summary.valence, 0) || 0;
+  const val = safeNum(valenceOverride != null ? valenceOverride : summary.valence, 0) || 0;
   const vol = safeNum(summary.volatility, 0) || 0;
 
   // Normalize per UI logic
@@ -37,11 +190,27 @@ function extractTimeSeries(transitsByDate) {
   if (!transitsByDate || typeof transitsByDate !== 'object') return [];
   const entries = [];
   for (const [date, v] of Object.entries(transitsByDate)) {
+    const seismo = v?.seismograph || v;
+    const balanceVal = safeNum(v?.balance?.valence);
+    const balanceInfo = balanceVal != null ? classifyValence(balanceVal) : null;
+    const sfdVal = safeNum(v?.sfd?.sfd);
     const row = {
       date,
-      magnitude: safeNum(v?.magnitude),
-      valence: safeNum(v?.valence),
-      volatility: safeNum(v?.volatility),
+      magnitude: safeNum(seismo?.magnitude),
+      valence: safeNum(seismo?.valence),
+      valence_calibrated: safeNum(seismo?.valence_calibrated ?? balanceVal),
+      volatility: safeNum(seismo?.volatility),
+      confidence: safeNum(seismo?.scaling_confidence),
+      balance_valence: balanceVal,
+      balance_label: balanceInfo?.term || null,
+      balance_emoji: balanceInfo?.emoji || null,
+      balance_polarity: balanceInfo?.polarity || null,
+      balance_version: v?.balance?.version || seismo?.valence_version || null,
+      balance_range: v?.balance?.range || seismo?.valence_range || null,
+      sfd: sfdVal,
+      s_plus: safeNum(v?.sfd?.sPlus),
+      s_minus: safeNum(v?.sfd?.sMinus),
+      sfd_verdict: verdictFromSfd(sfdVal),
       drivers: Array.isArray(v?.drivers) ? v.drivers : undefined
     };
     entries.push(row);
@@ -56,11 +225,15 @@ function extractNatalSummary(person) {
   const chart = person.chart || {};
   const birth = person.birth_data || {};
   // Prefer chart payload for placements/aspects if present
-  const placements = chart.planets || birth.planets || null;
+  const placementsList = Array.isArray(chart.planets)
+    ? chart.planets
+    : (Array.isArray(birth.planets) ? birth.planets : []);
+  const placements = splitPlacements(placementsList);
   const angles = chart.angles || birth.angles || null;
   const aspects = Array.isArray(person.aspects) ? person.aspects : (chart.aspects || []);
   return {
     placements,
+    anchors: buildAnchors(placementsList, angles),
     angles,
     major_aspects: aspects
   };
@@ -86,6 +259,148 @@ function extractRawGeometry(result) {
     };
   }
   return out;
+}
+
+function summarizeMeterChannels(transitsByDate) {
+  if (!transitsByDate || typeof transitsByDate !== 'object') {
+    return {
+      seismograph: { confidence: null, sample_size: 0 },
+      balance: null,
+      sfd: null
+    };
+  }
+
+  const entries = Object.values(transitsByDate);
+  if (!entries.length) {
+    return {
+      seismograph: { confidence: null, sample_size: 0 },
+      balance: null,
+      sfd: null
+    };
+  }
+
+  let confidenceSum = 0;
+  let confidenceCount = 0;
+  const balanceValues = [];
+  const sfdValues = [];
+  const sPlusValues = [];
+  const sMinusValues = [];
+
+  for (const entry of entries) {
+    const seismo = entry?.seismograph || entry;
+    if (seismo && typeof seismo.scaling_confidence === 'number' && Number.isFinite(seismo.scaling_confidence)) {
+      confidenceSum += seismo.scaling_confidence;
+      confidenceCount += 1;
+    }
+
+    const balVal = safeNum(entry?.balance?.valence);
+    if (balVal != null) balanceValues.push(balVal);
+
+    const sfd = safeNum(entry?.sfd?.sfd);
+    if (sfd != null) {
+      sfdValues.push(sfd);
+      const sPlus = safeNum(entry?.sfd?.sPlus);
+      if (sPlus != null) sPlusValues.push(sPlus);
+      const sMinus = safeNum(entry?.sfd?.sMinus);
+      if (sMinus != null) sMinusValues.push(sMinus);
+    }
+  }
+
+  const avg = (arr) => arr.length ? arr.reduce((sum, val) => sum + val, 0) / arr.length : null;
+
+  const confidence = confidenceCount ? + (confidenceSum / confidenceCount).toFixed(2) : null;
+  const balanceAvgRaw = avg(balanceValues);
+  const balanceAvg = balanceAvgRaw != null ? +balanceAvgRaw.toFixed(2) : null;
+  const balanceMeta = balanceAvg != null ? classifyValence(balanceAvg) : null;
+  const sfdAvgRaw = avg(sfdValues);
+  const sfdAvg = sfdAvgRaw != null ? +sfdAvgRaw.toFixed(2) : null;
+  const sPlusAvgRaw = avg(sPlusValues);
+  const sMinusAvgRaw = avg(sMinusValues);
+  const sPlusAvg = sPlusAvgRaw != null ? +sPlusAvgRaw.toFixed(2) : null;
+  const sMinusAvg = sMinusAvgRaw != null ? +sMinusAvgRaw.toFixed(2) : null;
+
+  return {
+    seismograph: {
+      confidence,
+      sample_size: confidenceCount
+    },
+    balance: balanceAvg != null ? {
+      value: balanceAvg,
+      label: balanceMeta?.term || null,
+      emoji: balanceMeta?.emoji || null,
+      polarity: balanceMeta?.polarity || (balanceAvg >= 0 ? 'positive' : 'negative'),
+      band: balanceMeta?.range || null,
+      sample_size: balanceValues.length,
+      version: 'v1.1',
+      range: [-5, 5]
+    } : null,
+    sfd: sfdAvg != null ? {
+      value: sfdAvg,
+      s_plus: sPlusAvg,
+      s_minus: sMinusAvg,
+      verdict: verdictFromSfd(sfdAvg),
+      sample_size: sfdValues.length,
+      version: 'v1.2',
+      range: [-5, 5]
+    } : null
+  };
+}
+
+function computeVectorIntegrity(transitsByDate) {
+  const base = { latent: [], suppressed: [], method: 'vector-scan-1', sample_size: 0 };
+  if (!transitsByDate || typeof transitsByDate !== 'object') return base;
+
+  const latentMap = new Map();
+  const suppressedMap = new Map();
+  let sampleDays = 0;
+
+  const LATENT_REASONS = new Set(['WEAK_WEIGHT']);
+  const SUPPRESSED_REASONS = new Set(['OUT_OF_CAP', 'DUPLICATE_PAIR', 'PRIMARY_DUP']);
+
+  for (const entry of Object.values(transitsByDate)) {
+    const rejections = Array.isArray(entry?.rejections) ? entry.rejections : [];
+    if (!rejections.length) continue;
+    sampleDays += 1;
+    for (const rej of rejections) {
+      const aspect = rej?.aspect || 'Unknown aspect';
+      const reasonRaw = (rej?.reason || '').toString().toUpperCase();
+      const orb = safeNum(rej?.orb);
+      let targetMap = null;
+      if (LATENT_REASONS.has(reasonRaw)) targetMap = latentMap;
+      else if (SUPPRESSED_REASONS.has(reasonRaw)) targetMap = suppressedMap;
+      if (!targetMap) continue;
+      if (!targetMap.has(aspect)) {
+        targetMap.set(aspect, { aspect, count: 0, total_orb: 0, orb_count: 0, reasons: {} });
+      }
+      const rec = targetMap.get(aspect);
+      rec.count += 1;
+      rec.reasons[reasonRaw] = (rec.reasons[reasonRaw] || 0) + 1;
+      if (orb != null) {
+        rec.total_orb += Math.abs(orb);
+        rec.orb_count += 1;
+      }
+    }
+  }
+
+  const finalize = (map) => Array.from(map.values()).map(item => {
+    const avgOrb = item.orb_count ? +(item.total_orb / item.orb_count).toFixed(2) : null;
+    const reasons = Object.entries(item.reasons)
+      .map(([reason, count]) => ({ reason, count }))
+      .sort((a, b) => b.count - a.count);
+    return {
+      aspect: item.aspect,
+      count: item.count,
+      average_orb: avgOrb,
+      reasons
+    };
+  }).sort((a, b) => b.count - a.count).slice(0, 5);
+
+  return {
+    latent: finalize(latentMap),
+    suppressed: finalize(suppressedMap),
+    method: 'vector-scan-1',
+    sample_size: sampleDays
+  };
 }
 
 // DATA-ONLY Polarity Cards structure: leave human-facing content null; include geometry hooks only
@@ -119,9 +434,51 @@ function composeWovenMapReport({ result, mode, period }) {
   const type = inferReportType(mode, !!b);
 
   const summary = a.derived?.seismograph_summary || null;
-  const integration = computeIntegrationFactors(summary);
+  const meterChannels = summarizeMeterChannels(a.chart?.transitsByDate);
+  const integration = computeIntegrationFactors(summary, meterChannels?.balance?.value ?? null);
   const timeSeries = extractTimeSeries(a.chart?.transitsByDate);
+  const vectorIntegrity = computeVectorIntegrity(a.chart?.transitsByDate);
   const hookStack = composeHookStack(result, { maxHooks: 4, minIntensity: 8 });
+
+  let balanceMeter = null;
+  if (summary) {
+    const magnitudeVal = safeNum(summary.magnitude);
+    const magnitudeInfo = classifyMagnitude(summary.magnitude);
+    const volatilityVal = safeNum(summary.volatility);
+    const volatilityInfo = classifyVolatility(summary.volatility);
+    const valenceVal = safeNum(summary.valence);
+    const valenceRaw = safeNum(summary.valence_raw);
+    const valenceRange = Array.isArray(summary.valence_range) ? summary.valence_range : [-5, 5];
+    const valenceVersion = summary.valence_version || null;
+    const balanceMeta = meterChannels?.balance || null;
+    balanceMeter = {
+      magnitude: {
+        value: magnitudeVal,
+        term: magnitudeInfo?.term || null
+      },
+      valence: {
+        value: valenceVal,
+        raw_value: valenceRaw,
+        normalized: balanceMeta?.value ?? valenceVal,
+        term: balanceMeta?.label || null,
+        emoji: balanceMeta?.emoji || null,
+        polarity: balanceMeta?.polarity || (valenceVal >= 0 ? 'positive' : 'negative'),
+        band: balanceMeta?.band || null,
+        range: balanceMeta?.range || valenceRange,
+        version: balanceMeta?.version || valenceVersion,
+        sample_size: balanceMeta?.sample_size ?? summary.valence_sample_size ?? null
+      },
+      volatility: {
+        value: volatilityVal,
+        term: volatilityInfo?.term || null,
+        emoji: volatilityInfo?.emoji || null
+      },
+      confidence: meterChannels?.seismograph?.confidence ?? null,
+      confidence_sample_size: meterChannels?.seismograph?.sample_size ?? 0,
+      balance_channel: balanceMeta ? { ...balanceMeta } : null,
+      support_friction: meterChannels?.sfd ? { ...meterChannels.sfd } : null
+    };
+  }
 
   const report = {
     schema: 'WM-WovenMap-1.0',
@@ -149,20 +506,12 @@ function composeWovenMapReport({ result, mode, period }) {
         timezone: b?.details?.timezone || null
       } : null
     },
-    balance_meter: summary ? {
-      magnitude: summary.magnitude,
-      valence: summary.valence,
-      volatility: summary.volatility
-    } : null,
+    balance_meter: balanceMeter,
     hook_stack: hookStack,
     integration_factors: integration,
     time_series: timeSeries,
     natal_summary: extractNatalSummary(a),
-    vector_integrity: {
-      latent: [], // TODO: compute heuristic from aspect network
-      suppressed: [], // TODO: compute heuristic from counter-aspects
-      method: 'stub-0'
-    },
+    vector_integrity: vectorIntegrity,
     polarity_cards: buildPolarityCardsHooks(a), // DATA hooks only, no VOICE
     mirror_voice: null, // reserved for Raven
     raw_geometry: extractRawGeometry(result),


### PR DESCRIPTION
## Summary
- apply Balance Meter v1.1 calibration when summarizing seismograph valence, keeping raw values alongside normalized range metadata
- propagate calibrated valence fields, versions, and ranges through the woven map composer time-series and Balance Meter summary payloads

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf654c9f4c832f87ba14c993af6eee