### PR TITLE
Refine valence metrics and reporting scaffolding

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -159,13 +159,14 @@ function pickHook(t:string){
       if (jsonMatch) {
         const data = JSON.parse(jsonMatch[0]);
         const magnitude = data.balance_meter?.magnitude?.value;
-        const valence = data.balance_meter?.valence?.value;
-        
-        // Route based on severity
-        if (magnitude >= 4 && valence <= -10) {
-          return 'Crisis & Structural Overload · Maximum Threshold';
-        } else if (magnitude >= 3 && valence <= -5) {
-          return 'Pressure & Restriction · Storm Systems';
+        const valence = data.balance_meter?.valence?.value ?? data.balance_meter?.valence_bounded;
+
+        if (typeof magnitude === 'number' && typeof valence === 'number') {
+          if (magnitude >= 4 && valence <= -4) {
+            return 'Crisis & Structural Overload · Maximum Threshold';
+          } else if (magnitude >= 3 && valence <= -3) {
+            return 'Pressure & Restriction · Storm Systems';
+          }
         }
       }
     } catch (e) {

--- a/lib/mathbrain/adapter.ts
+++ b/lib/mathbrain/adapter.ts
@@ -15,7 +15,12 @@ function extractClimate(payload: any): any {
   const balance = payload.balance_meter || payload.summary?.balance_meter;
   if (balance?.climate) return balance.climate;
   if (balance?.climate_line) {
-    return { line: balance.climate_line, magnitude: balance.magnitude, valence: balance.valence, volatility: balance.volatility };
+    return {
+      line: balance.climate_line,
+      magnitude: balance.magnitude,
+      valence: balance.valence_bounded ?? balance.valence,
+      volatility: balance.volatility
+    };
   }
   return null;
 }

--- a/lib/reporting/metric-labels.js
+++ b/lib/reporting/metric-labels.js
@@ -1,0 +1,109 @@
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+const VALENCE_LEVELS = [
+  { min: -5, max: -4, label: 'Collapse', emoji: '🌋', polarity: 'negative', code: 'collapse' },
+  { min: -4, max: -2.5, label: 'Friction', emoji: '⚔️', polarity: 'negative', code: 'friction' },
+  { min: -2.5, max: -1, label: 'Drag', emoji: '🌪️', polarity: 'negative', code: 'drag' },
+  { min: -1, max: 1, label: 'Equilibrium', emoji: '⚖️', polarity: 'neutral', code: 'equilibrium' },
+  { min: 1, max: 2.5, label: 'Flow', emoji: '🌊', polarity: 'positive', code: 'flow' },
+  { min: 2.5, max: 5.01, label: 'Expansion', emoji: '🦋', polarity: 'positive', code: 'expansion' },
+];
+
+const MAGNITUDE_LEVELS = [
+  { max: 0.5, label: 'Trace' },
+  { max: 1.5, label: 'Pulse' },
+  { max: 2.5, label: 'Wave' },
+  { max: 3.5, label: 'Surge' },
+  { max: 4.5, label: 'Peak' },
+  { max: Infinity, label: 'Threshold' },
+];
+
+const VOLATILITY_LEVELS = [
+  { max: 0.5, label: 'Aligned Flow', emoji: '➿' },
+  { max: 2, label: 'Cycled Pull', emoji: '🔄' },
+  { max: 3, label: 'Mixed Paths', emoji: '🔀' },
+  { max: 5, label: 'Fragment Scatter', emoji: '🧩' },
+  { max: Infinity, label: 'Vortex Dispersion', emoji: '🌀' },
+];
+
+function safeNumber(value, fallback = null) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : fallback;
+}
+
+function classifyValence(value) {
+  const num = safeNumber(value, null);
+  if (num == null) return null;
+  const bounded = clamp(num, -5, 5);
+  const tier = VALENCE_LEVELS.find(level => bounded >= level.min && bounded < level.max);
+  if (!tier) {
+    return {
+      value: +bounded.toFixed(2),
+      label: null,
+      emoji: null,
+      polarity: bounded >= 0 ? 'positive' : 'negative',
+      band: null,
+      code: null,
+    };
+  }
+  return {
+    value: +bounded.toFixed(2),
+    label: tier.label,
+    emoji: tier.emoji,
+    polarity: tier.polarity,
+    band: [tier.min, tier.max],
+    code: tier.code,
+  };
+}
+
+function classifyMagnitude(value) {
+  const num = safeNumber(value, null);
+  if (num == null) return null;
+  const tier = MAGNITUDE_LEVELS.find(level => num <= level.max);
+  return {
+    value: +num.toFixed(2),
+    label: tier ? tier.label : null,
+  };
+}
+
+function classifyVolatility(value) {
+  const num = safeNumber(value, null);
+  if (num == null) return null;
+  const tier = VOLATILITY_LEVELS.find(level => num <= level.max);
+  return {
+    value: +num.toFixed(2),
+    label: tier ? tier.label : null,
+    emoji: tier ? tier.emoji : null,
+  };
+}
+
+function classifySfd(value) {
+  const num = safeNumber(value, null);
+  if (num == null) return null;
+  const bounded = clamp(num, -5, 5);
+  let disc = 0;
+  let label = 'scaffolding mixed';
+  if (bounded >= 1) {
+    disc = 1;
+    label = 'scaffolding present';
+  } else if (bounded <= -1) {
+    disc = -1;
+    label = 'scaffolding cut';
+  }
+  return {
+    value: +bounded.toFixed(2),
+    disc,
+    label,
+  };
+}
+
+module.exports = {
+  VALENCE_LEVELS,
+  MAGNITUDE_LEVELS,
+  VOLATILITY_LEVELS,
+  classifyValence,
+  classifyMagnitude,
+  classifyVolatility,
+  classifySfd,
+  clamp,
+};

--- a/lib/server/astrology-mathbrain.js
+++ b/lib/server/astrology-mathbrain.js
@@ -4,6 +4,13 @@
 const { aggregate } = require('../../src/seismograph');
 const { _internals: seismoInternals } = require('../../src/seismograph');
 const { computeSFD, computeBalanceValence } = require('../../src/balance-meter');
+const {
+  classifyValence,
+  classifyMagnitude,
+  classifyVolatility,
+  classifySfd,
+  clamp,
+} = require('../reporting/metric-labels');
 const API_BASE_URL = 'https://astrologer.p.rapidapi.com';
 
 const API_ENDPOINTS = {
@@ -53,6 +60,9 @@ function stripGraphicsDeep(obj) {
 const MATH_BRAIN_VERSION = '0.2.1'; // Single source of truth for version
 const EPHEMERIS_SOURCE = 'AstrologerAPI-v4';
 const CALIBRATION_BOUNDARY = '2025-09-05';
+const SEISMOGRAPH_VERSION = 'v1.0';
+const BALANCE_CALIBRATION_VERSION = 'v1.1';
+const SFD_VERSION = 'v1.2';
 
 function normalizeStep(step) {
   const s = String(step || '').toLowerCase();
@@ -109,6 +119,14 @@ function normalizeRelocationMode(mode) {
   if (['custom', 'manual', 'user'].includes(lower)) return 'Custom';
   if (['midpoint', 'mid-point'].includes(lower)) return 'Midpoint';
   return token;
+}
+
+function verdictFromSfd(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return null;
+  if (num >= 1) return 'stabilizers prevail';
+  if (num <= -1) return 'stabilizers cut';
+  return 'stabilizers mixed';
 }
 
 function evaluateMirrorReadiness(result) {
@@ -582,6 +600,8 @@ function weightAspect(a){
   return +(base * tightness * lumOrAngle).toFixed(4);
 }
 
+const WEIGHTS_LEGEND = Object.freeze({ major: 1.0, minor: 0.55, harmonic: 0.45, fallback: 0.4 });
+
 function enrichDailyAspects(rawList){
   if (!Array.isArray(rawList)) return { raw: [], filtered: [], hooks: [], rejections: [], counts: { raw:0, filtered:0, hooks:0 } };
   const enriched = [];
@@ -620,12 +640,16 @@ function enrichDailyAspects(rawList){
       p2_isAngle: ['Ascendant','Medium_Coeli','Descendant','Imum_Coeli'].includes(p2),
       p1_class: p1Class,
       p2_class: p2Class,
-      effective_cap: effectiveCap
+      effective_cap: effectiveCap,
+      p1_house: a.p1_house ?? a.p1_house_num ?? null,
+      p2_house: a.p2_house ?? a.p2_house_num ?? a.house ?? null,
+      house_target: a.p2_house ?? a.house_target ?? null
     };
     if (dropReason){
       rejections.push({ aspect: `${p1} ${aspectName} ${p2}`, reason: dropReason, orb });
     } else {
       rec._weight = weightAspect(rec);
+      rec.weight_final = rec._weight;
       enriched.push(rec);
     }
   }
@@ -1201,6 +1225,7 @@ function calculateSeismograph(transitsByDate, retroFlagsByDate = {}) {
   const valenceHistory = []; // Track for trend analysis
   const rawValenceSeries = [];
   const calibratedValenceSeries = [];
+  const boundedValenceSeries = [];
 
   for (let i = 0; i < days.length; i++) {
     const d = days[i];
@@ -1240,95 +1265,150 @@ function calculateSeismograph(transitsByDate, retroFlagsByDate = {}) {
     const rollingContext = rollingMagnitudes.length >= 1 ? { magnitudes: [...rollingMagnitudes] } : null;
     
     const agg = aggregate(aspectsForAggregate, prev, { rollingContext });
-    rawValenceSeries.push(agg.valence);
+    const valenceRaw = Number.isFinite(agg.valence) ? agg.valence : 0;
+    rawValenceSeries.push(valenceRaw);
 
-  // Determine scaling strategy and confidence
-  let scalingStrategy = 'prior';
-  const nContext = rollingMagnitudes.length;
-  if (nContext >= 14) scalingStrategy = 'rolling';
-  else if (nContext >= 2) scalingStrategy = 'blended';
-  const scaleConfidence = Math.min(1, nContext / 14);
-    
+    // Determine scaling strategy and confidence
+    let scalingStrategy = 'prior';
+    const nContext = rollingMagnitudes.length;
+    if (nContext >= 14) scalingStrategy = 'rolling';
+    else if (nContext >= 2) scalingStrategy = 'blended';
+    const scaleConfidence = Math.min(1, nContext / 14);
+
     // Track rolling magnitudes using the original magnitude before normalization (keep last 14 days)
     const magnitudeToTrack = agg.originalMagnitude || agg.rawMagnitude || agg.magnitude;
     rollingMagnitudes.push(magnitudeToTrack);
     if (rollingMagnitudes.length > 14) rollingMagnitudes.shift();
-    
-    // Track valence history (keep last 7 days for trend)
-    valenceHistory.push(agg.valence);
-    if (valenceHistory.length > 7) valenceHistory.shift();
-    
+
     // Identify retrograde recursion aspects
     const retrogradeAspects = enrichedWithRetrograde.filter(a => a.retrograde_involved);
-    
+
     // Dispersion-based volatility override (std deviation of hook weights)
     let dispersionVol = 0;
     if (enriched.hooks.length >= 2) {
       const weights = enriched.hooks.map(h => h._weight || 0);
-      const meanW = weights.reduce((s,v)=>s+v,0)/weights.length;
-      const variance = weights.reduce((s,v)=>s+Math.pow(v-meanW,2),0)/weights.length;
-      dispersionVol = Math.min(10, Math.sqrt(variance) * 10); // scale
+      const meanW = weights.reduce((s, v) => s + v, 0) / weights.length;
+      const variance = weights.reduce((s, v) => s + Math.pow(v - meanW, 2), 0) / weights.length;
+      dispersionVol = Math.min(10, Math.sqrt(variance) * 10);
     }
 
-    // Build compact drivers reflecting top hooks
-    const driversCompact = (enriched.hooks || []).map(h => ({
-      a: h.p1_name,
-      b: h.p2_name,
-      type: h._aspect || h.aspect || h.type,
-      orb: h._orb != null ? h._orb : (typeof h.orb === 'number' ? h.orb : (typeof h.orbit === 'number' ? h.orbit : null)),
-      applying: typeof h.applying === 'boolean' ? h.applying : undefined,
-      weight: typeof h._weight === 'number' ? h._weight : weightAspect(h),
-      // compatibility fields for existing composers/templates
-      planet1: h.p1_name,
-      planet2: h.p2_name,
-      name: h._aspect || h.aspect || h.type,
-      first_planet: h.p1_name,
-      second_planet: h.p2_name,
-      is_transit: true
-    }));
+    // Compute balance and SFD upfront for canonical valence values
+    let balanceVal = null;
+    let sfdData = null;
+    try {
+      const computedBalance = computeBalanceValence(enriched.filtered);
+      const { SFD, Splus, Sminus } = computeSFD(enriched.filtered);
+      if (Number.isFinite(computedBalance)) {
+        balanceVal = +computedBalance.toFixed(2);
+        calibratedValenceSeries.push(balanceVal);
+      }
+      if (Number.isFinite(SFD)) {
+        sfdData = {
+          SFD: +SFD.toFixed(2),
+          Splus: Number.isFinite(Splus) ? +Splus.toFixed(2) : null,
+          Sminus: Number.isFinite(Sminus) ? +Sminus.toFixed(2) : null
+        };
+      }
+    } catch (e) {
+      logger.warn('Balance/SFD computation failed for day', d, e.message);
+    }
+
+    const magnitudeInfo = classifyMagnitude(agg.magnitude);
+    const magnitudeLabel = magnitudeInfo?.label || null;
+    const boundedBase = balanceVal != null ? balanceVal : clamp(valenceRaw, -5, 5);
+    const valenceInfo = classifyValence(boundedBase);
+    const valenceBounded = valenceInfo?.value ?? +boundedBase.toFixed(2);
+    boundedValenceSeries.push(valenceBounded);
+
+    // Track valence history (keep last 7 days for trend)
+    valenceHistory.push(valenceBounded);
+    if (valenceHistory.length > 7) valenceHistory.shift();
+
+    const volatilityInfo = classifyVolatility(dispersionVol);
+
+    // Build compact drivers reflecting top hooks (already computed above)
+    const driversCompact = (enriched.hooks || []).map(h => {
+      const weightFinal = typeof h._weight === 'number' ? h._weight : weightAspect(h);
+      return {
+        a: h.p1_name,
+        b: h.p2_name,
+        type: h._aspect || h.aspect || h.type,
+        orb: h._orb != null ? h._orb : (typeof h.orb === 'number' ? h.orb : (typeof h.orbit === 'number' ? h.orbit : null)),
+        applying: typeof h.applying === 'boolean' ? h.applying : undefined,
+        weight: weightFinal,
+        weight_final: weightFinal,
+        house_target: h.house_target ?? h.p2_house ?? null,
+        planet1: h.p1_name,
+        planet2: h.p2_name,
+        name: h._aspect || h.aspect || h.type,
+        first_planet: h.p1_name,
+        second_planet: h.p2_name,
+        is_transit: true
+      };
+    });
+
+    const sfdMeta = sfdData ? classifySfd(sfdData.SFD) : null;
+    const calibrationMode = balanceVal != null ? BALANCE_CALIBRATION_VERSION : 'bounded-only';
 
     const dayEntry = {
       seismograph: {
         magnitude: agg.magnitude,
-        valence: agg.valence,
-        volatility: dispersionVol, // use dispersion measure
+        magnitude_label: magnitudeLabel,
+        valence_bounded: valenceBounded,
+        valence: valenceBounded,
+        valence_label: valenceInfo?.label || null,
+        valence_code: valenceInfo?.code || null,
+        valence_raw_unbounded: +valenceRaw.toFixed(2),
+        valence_calibrated: balanceVal != null ? balanceVal : valenceBounded,
+        valence_range: [-5, 5],
+        valence_version: calibrationMode,
+        valence_polarity: valenceInfo?.polarity || (valenceBounded >= 0 ? 'positive' : 'negative'),
+        volatility: dispersionVol,
+        volatility_label: volatilityInfo?.label || null,
         rawMagnitude: agg.rawMagnitude,
         originalMagnitude: agg.originalMagnitude,
         scaling_strategy: scalingStrategy,
         scaling_confidence: +scaleConfidence.toFixed(2),
-        valence_calibrated: null,
-        valence_range: [-5, 5],
-        valence_version: null
+        version: SEISMOGRAPH_VERSION
       },
       aspects: rawDayAspects,
       filtered_aspects: enrichedWithRetrograde,
-      // Keep legacy 'hooks' for backward compatibility; add normalized 'drivers'
       hooks: enriched.hooks,
       drivers: driversCompact,
       rejections: enriched.rejections,
       counts: enriched.counts,
       transit_table: transitTable,
       retrograde_aspects: retrogradeAspects,
+      weights_legend: WEIGHTS_LEGEND,
+      balance: {
+        magnitude: agg.magnitude,
+        magnitude_label: magnitudeLabel,
+        valence_bounded: valenceBounded,
+        valence: valenceBounded,
+        valence_label: valenceInfo?.label || null,
+        valence_code: valenceInfo?.code || null,
+        version: BALANCE_CALIBRATION_VERSION,
+        calibration_mode: calibrationMode,
+        range: [-5, 5]
+      },
       valence_trend: valenceHistory.length > 1 ? calculateTrend(valenceHistory) : 0
     };
 
-    // Balance/SFD computation (always on in WM-Chart-1.2)
-    try {
-      const balanceVal = computeBalanceValence(enriched.filtered);
-      const { SFD, Splus, Sminus } = computeSFD(enriched.filtered);
-      if (Number.isFinite(balanceVal)) {
-        calibratedValenceSeries.push(balanceVal);
-        dayEntry.seismograph.valence_calibrated = balanceVal;
-        dayEntry.seismograph.valence_version = 'v1.1';
-      }
-      dayEntry.balance = { magnitude: agg.magnitude, valence: balanceVal, version: 'v1.1', range: [-5, 5] };
-      dayEntry.sfd = { sfd: SFD, sPlus: Splus, sMinus: Sminus, version: 'v1.2' };
-    } catch (e) {
-      logger.warn('Balance/SFD computation failed for day', d, e.message);
+    if (sfdData) {
+      dayEntry.sfd = {
+        sfd_cont: sfdData.SFD,
+        sfd_disc: sfdMeta?.disc ?? (sfdData.SFD >= 1 ? 1 : sfdData.SFD <= -1 ? -1 : 0),
+        sfd_label: sfdMeta?.label || verdictFromSfd(sfdData.SFD),
+        s_plus: sfdData.Splus,
+        s_minus: sfdData.Sminus,
+        verdict: verdictFromSfd(sfdData.SFD),
+        version: SFD_VERSION,
+        range: [-5, 5]
+      };
     }
 
     daily[d] = dayEntry;
-    prev = { scored: agg.scored, Y_effective: agg.valence };
+    prev = { scored: agg.scored, Y_effective: valenceBounded };
     prevDayFiltered = enriched.filtered;
   }
 
@@ -1336,17 +1416,37 @@ function calculateSeismograph(transitsByDate, retroFlagsByDate = {}) {
   const X = Object.values(daily).reduce((s, d) => s + d.seismograph.magnitude, 0) / numDays;
   const VI = Object.values(daily).reduce((s, d) => s + d.seismograph.volatility, 0) / numDays;
   const rawAvg = rawValenceSeries.length ? rawValenceSeries.reduce((sum, val) => sum + val, 0) / rawValenceSeries.length : 0;
+  const boundedAvg = boundedValenceSeries.length ? boundedValenceSeries.reduce((sum, val) => sum + val, 0) / boundedValenceSeries.length : 0;
   const calibratedAvgBase = calibratedValenceSeries.length
     ? calibratedValenceSeries.reduce((sum, val) => sum + val, 0) / calibratedValenceSeries.length
-    : rawAvg;
-  const calibratedAvg = Math.max(-5, Math.min(5, calibratedAvgBase));
+    : boundedAvg;
+  const calibratedAvg = clamp(calibratedAvgBase, -5, 5);
+  const magnitudeInfo = classifyMagnitude(X);
+  const valenceInfo = classifyValence(calibratedAvg);
+  const volatilityInfo = classifyVolatility(VI);
+  const summaryValenceVersion = calibratedValenceSeries.length ? BALANCE_CALIBRATION_VERSION : 'bounded-only';
   const summary = {
     magnitude: +X.toFixed(2),
+    magnitude_label: magnitudeInfo?.label || null,
+    valence_bounded: +calibratedAvg.toFixed(2),
     valence: +calibratedAvg.toFixed(2),
-    valence_raw: +rawAvg.toFixed(2),
-    valence_version: calibratedValenceSeries.length ? 'v1.1' : 'raw-clamped',
+    valence_label: valenceInfo?.label || null,
+    valence_code: valenceInfo?.code || null,
+    valence_emoji: valenceInfo?.emoji || null,
+    valence_polarity: valenceInfo?.polarity || (calibratedAvg >= 0 ? 'positive' : 'negative'),
+    valence_raw_unbounded: +rawAvg.toFixed(2),
+    valence_version: summaryValenceVersion,
     valence_range: [-5, 5],
-    volatility: +VI.toFixed(2)
+    volatility: +VI.toFixed(2),
+    volatility_label: volatilityInfo?.label || null,
+    volatility_emoji: volatilityInfo?.emoji || null,
+    calibration_mode: summaryValenceVersion,
+    version: {
+      seismograph: SEISMOGRAPH_VERSION,
+      balance: BALANCE_CALIBRATION_VERSION,
+      sfd: SFD_VERSION,
+      calibration_mode: summaryValenceVersion
+    }
   };
   if (calibratedValenceSeries.length) {
     summary.valence_sample_size = calibratedValenceSeries.length;
@@ -2277,7 +2377,11 @@ exports.handler = async function(event) {
         tz_conflict: false,
         geometry_ready: true,
         calibration_boundary: CALIBRATION_BOUNDARY,
-        engine_versions: { seismograph: 'v1.0', balance: 'v1.1', sfd: 'v1.2' },
+        engine_versions: {
+          seismograph: SEISMOGRAPH_VERSION,
+          balance: BALANCE_CALIBRATION_VERSION,
+          sfd: SFD_VERSION
+        },
         time_meta_a: deriveTimeMetaWithPolicy(personAOriginal, timePolicy),
         // New provenance fields (stamped after pass/body are finalized below)
         house_system: undefined,
@@ -2325,11 +2429,13 @@ exports.handler = async function(event) {
         })();
         const currentLocation = tl?.current_location || relocationLabel || (aLocal?.city && aLocal?.nation ? `${aLocal.city}, ${aLocal.nation}` : undefined);
         const houseSystem = tl?.house_system || 'Placidus';
+        const normalizedTz = normalizeTimezone(tzSource);
         const ctx = {
           applies: ctxApplies,
           method: ctxMethod,
           house_system: houseSystem,
-          tz: normalizeTimezone(tzSource)
+          tz: normalizedTz,
+          requested_tz: normalizedTz
         };
         if (currentLocation) ctx.current_location = currentLocation;
         if (coordsBlock) ctx.coords = coordsBlock;
@@ -2344,12 +2450,13 @@ exports.handler = async function(event) {
       if (transCtx) {
         const ctxTz = transCtx.tz;
         if (ctxTz && ctxTz !== result.provenance.timezone) {
-          tzConflict = true;
-          conflictReason = relocationApplied
-            ? 'translocation tz mismatch'
-            : 'translocation tz present without relocation';
-          if (!relocationApplied) {
+          if (relocationApplied) {
+            tzConflict = true;
+            conflictReason = 'translocation tz mismatch';
+          } else {
             transCtx.tz = null;
+            tzConflict = false;
+            conflictReason = null;
           }
         }
       }

--- a/poetic-brain/src/index.ts
+++ b/poetic-brain/src/index.ts
@@ -96,17 +96,18 @@ function normalizeHooks(hooks?: Array<string | HookObject>): HookObject[] {
 
 function seismographSummary(payload: InputPayload): { headline: string; details: string } {
   const mag = num(payload.seismograph?.magnitude);
-  const val = num(payload.seismograph?.valence);
+  const val = num(payload.seismograph?.valence_bounded ?? payload.seismograph?.valence);
   const vol = num(payload.seismograph?.volatility);
   const { band, label } = magnitudeBand(mag);
   const vt = classifyValenceTone(val);
   const vv = classifyVolatility(vol);
   const parts: string[] = [];
   parts.push(`Magnitude ${mag !== undefined ? mag.toFixed(2) : '—'} (⚡ ${label} at ${band})`);
-  parts.push(`Valence ${val !== undefined ? val.toFixed(2) : '—'} (${vt.descriptor})`);
+  const valLabel = payload.seismograph?.valence_label || vt.descriptor;
+  parts.push(`Valence ${val !== undefined ? val.toFixed(2) : '—'} (${valLabel})`);
   parts.push(`Volatility ${vol !== undefined ? vol.toFixed(2) : '—'} (${vv.label})`);
   return {
-    headline: `${label} with ${vt.descriptor}`,
+    headline: `${label} with ${valLabel}`,
     details: parts.join(' · '),
   };
 }
@@ -147,7 +148,7 @@ function buildMirrorVoice(payload: InputPayload): string {
 
 function buildPolarityCard(payload: InputPayload): string {
   const mag = num(payload.seismograph?.magnitude);
-  const val = num(payload.seismograph?.valence);
+  const val = num(payload.seismograph?.valence_bounded ?? payload.seismograph?.valence);
   const vol = num(payload.seismograph?.volatility);
   const { band, label } = magnitudeBand(mag);
   const vt = classifyValenceTone(val);

--- a/src/parsers/seismograph-md.js
+++ b/src/parsers/seismograph-md.js
@@ -82,11 +82,11 @@
     const magnitude = magMatch ? parseFloat(magMatch[1]) : 0;
     
     // Extract valence (Val 🌋 X.X)
-    const valMatch = tripleChannelText.match(/Val\s*🌋\s*([0-9.+-]+)/);
+    const valMatch = tripleChannelText.match(/Val\s*[^0-9+\-]{0,4}\s*([+-]?\d+(?:\.\d+)?)/);
     const valence = valMatch ? parseFloat(valMatch[1]) : 0;
-    
+
     // Extract balance (Bal 💎 X.X)
-    const balMatch = tripleChannelText.match(/Bal\s*[💎🦋🔥]\s*([0-9.+-]+)/);
+    const balMatch = tripleChannelText.match(/Bal\s*[^0-9+\-]{0,4}\s*([+-]?\d+(?:\.\d+)?)/);
     const balance = balMatch ? parseFloat(balMatch[1]) : 0;
     
     return {

--- a/src/reporters/comparative-report.js
+++ b/src/reporters/comparative-report.js
@@ -24,12 +24,20 @@
     return byDate;
   }
 
+  function getSeismographValence(seismo){
+    if (!seismo || typeof seismo !== 'object') return null;
+    if (typeof seismo.valence_bounded === 'number') return seismo.valence_bounded;
+    if (typeof seismo.valence === 'number') return seismo.valence;
+    return null;
+  }
+
   function simpleHeuristicScore(seismo, dayHealth){
     // mirror calculateCorrelationScore used in index.html, but local & minimal
     let score = 0, parts = 0;
-    if (typeof dayHealth.mood_valence === 'number' && typeof seismo.valence === 'number'){
+    const seismoVal = getSeismographValence(seismo);
+    if (typeof dayHealth.mood_valence === 'number' && seismoVal != null){
       const hv = Math.max(-1, Math.min(1, dayHealth.mood_valence));
-      const sv = Math.max(-1, Math.min(1, (seismo.valence||0) / 5));
+      const sv = Math.max(-1, Math.min(1, (seismoVal||0) / 5));
       score += 1 - Math.abs(hv - sv) / 2; parts++;
     }
     if (typeof dayHealth.hrv === 'number' && typeof seismo.volatility === 'number'){
@@ -89,7 +97,8 @@
     dates.forEach(d => {
       const s = seismoMap[d]||{}; const h = healthByDate[d]||{};
       // Valence normalization
-      const sv = typeof s.valence==='number' ? Math.max(-1, Math.min(1, (s.valence||0)/5)) : null;
+      const seismoValRaw = getSeismographValence(s);
+      const sv = seismoValRaw != null ? Math.max(-1, Math.min(1, (seismoValRaw||0)/5)) : null;
       const hv = typeof h.mood_valence==='number' ? Math.max(-1, Math.min(1, h.mood_valence)) : null;
       if (sv!=null && hv!=null) { arr.s_val.push(sv); arr.h_val.push(hv); }
       // Magnitude vs intensity proxy: prefer mood_label_count if present; else derive from sleep inverse to keep example minimal
@@ -188,7 +197,7 @@
       let prevMood = null;
       dates.forEach(d => {
         const s = seismoMap[d]||{}; const h = healthByDate[d]||{};
-        const s_val = typeof s.valence==='number' ? Math.max(-1, Math.min(1, (s.valence||0)/5)) : null;
+        const s_val = seismoValRaw != null ? Math.max(-1, Math.min(1, (seismoValRaw||0)/5)) : null;
         const h_val = typeof h.mood_valence==='number' ? Math.max(-1, Math.min(1, h.mood_valence)) : null;
         const s_mag = typeof s.magnitude==='number' ? Math.max(0, Math.min(1, (s.magnitude||0)/5)) : null;
         const labelCount = typeof h.mood_label_count==='number' ? h.mood_label_count : null;
@@ -267,7 +276,7 @@
       const row = [
         d,
         fmt(s.magnitude),
-        fmt(s.valence),
+        fmt(getSeismographValence(s)),
         fmt(s.volatility)
       ];
       if (hasHRV) row.push(fmt(h.hrv));
@@ -294,7 +303,8 @@
       let prevMood = null;
       dates.forEach(d => {
         const s = seismoMap[d]||{}; const h = healthByDate[d]||{};
-        const s_val = typeof s.valence==='number' ? Math.max(-1, Math.min(1, (s.valence||0)/5)) : null;
+        const sValBounded = getSeismographValence(s);
+        const s_val = sValBounded != null ? Math.max(-1, Math.min(1, (sValBounded||0)/5)) : null;
         const h_val = typeof h.mood_valence==='number' ? Math.max(-1, Math.min(1, h.mood_valence)) : null;
         const s_mag = typeof s.magnitude==='number' ? Math.max(0, Math.min(1, (s.magnitude||0)/5)) : null;
         const labelCount = typeof h.mood_label_count==='number' ? h.mood_label_count : null;

--- a/src/reporters/raw-math-composer.js
+++ b/src/reporters/raw-math-composer.js
@@ -48,9 +48,17 @@
       parts.push(table(['Transit','Natal','Type','Orb','Phase','Exact'], rows));
     }
     if(transits.seismograph_daily && transits.seismograph_daily.length){
-      const rows = transits.seismograph_daily.map(s=>[
-        s.date, s.magnitude, s.valence, s.volatility, (s.drivers||[]).join('; ')
-      ]);
+      const rows = transits.seismograph_daily.map(s=>{
+        const valence = (typeof s.valence_bounded === 'number') ? s.valence_bounded : s.valence;
+        const label = s.valence_label ? ` (${s.valence_label})` : '';
+        return [
+          s.date,
+          s.magnitude,
+          valence != null ? `${valence}${label}` : valence,
+          s.volatility,
+          (s.drivers||[]).join('; ')
+        ];
+      });
       parts.push('## Seismograph Daily');
       parts.push(table(['Date','Mag','Val','Vol','Drivers'], rows));
     }

--- a/test-transit-fallback.js
+++ b/test-transit-fallback.js
@@ -103,7 +103,7 @@ async function testTransitFallback() {
     if (seismo) {
       console.log('📈 Seismograph Data:');
       console.log(`Magnitude: ${seismo.magnitude}`);
-      console.log(`Valence: ${seismo.valence}`); 
+      console.log(`Valence: ${seismo.valence_bounded ?? seismo.valence}`);
       console.log(`Volatility: ${seismo.volatility}`);
       console.log('');
     }

--- a/wm-chart-schema-test.js
+++ b/wm-chart-schema-test.js
@@ -5,19 +5,26 @@ const samplePayload = {
   "date": "2025-09-05",
   "seismograph": {
     "magnitude": 5.0,
-    "valence": -5.0,
+    "magnitude_label": "Threshold",
+    "valence_bounded": -5.0,
+    "valence_label": "Collapse",
     "volatility": 4.2,
+    "volatility_label": "Fragment Scatter",
     "version": "v1.0"
   },
   "balance": {
     "magnitude": 5.0,
-    "valence": -3.0,
-    "version": "v1.1"
+    "valence_bounded": -3.0,
+    "valence_label": "Friction",
+    "version": "v1.1",
+    "calibration_mode": "v1.1"
   },
   "sfd": {
-    "sfd": -1.5,
-    "sPlus": 1.2,
-    "sMinus": 2.7,
+    "sfd_cont": -1.5,
+    "sfd_disc": -1,
+    "sfd_label": "scaffolding cut",
+    "s_plus": 1.2,
+    "s_minus": 2.7,
     "version": "v1.2"
   },
   "meta": {
@@ -64,11 +71,11 @@ function validatePayload(payload) {
   // Check required numeric fields
   const requiredNumbers = [
     ['seismograph.magnitude', payload.seismograph?.magnitude],
-    ['seismograph.valence', payload.seismograph?.valence],
-    ['balance.valence', payload.balance?.valence],
-    ['sfd.sfd', payload.sfd?.sfd],
-    ['sfd.sPlus', payload.sfd?.sPlus],
-    ['sfd.sMinus', payload.sfd?.sMinus]
+    ['seismograph.valence_bounded', payload.seismograph?.valence_bounded],
+    ['balance.valence_bounded', payload.balance?.valence_bounded],
+    ['sfd.sfd_cont', payload.sfd?.sfd_cont],
+    ['sfd.s_plus', payload.sfd?.s_plus],
+    ['sfd.s_minus', payload.sfd?.s_minus]
   ];
 
   requiredNumbers.forEach(([path, value]) => {
@@ -82,15 +89,15 @@ function validatePayload(payload) {
     errors.push('Seismograph magnitude must be 0-10');
   }
   
-  if (payload.seismograph?.valence < -5 || payload.seismograph?.valence > 5) {
+  if (payload.seismograph?.valence_bounded < -5 || payload.seismograph?.valence_bounded > 5) {
     errors.push('Seismograph valence must be -5 to +5');
   }
-  
-  if (payload.balance?.valence < -5 || payload.balance?.valence > 5) {
+
+  if (payload.balance?.valence_bounded < -5 || payload.balance?.valence_bounded > 5) {
     errors.push('Balance valence must be -5 to +5');
   }
-  
-  if (payload.sfd?.sfd < -5 || payload.sfd?.sfd > 5) {
+
+  if (payload.sfd?.sfd_cont < -5 || payload.sfd?.sfd_cont > 5) {
     errors.push('SFD value must be -5 to +5');
   }
 
@@ -121,13 +128,13 @@ if (!result.valid) {
   };
   
   const mag = result.payload.seismograph.magnitude.toFixed(1);
-  const val = result.payload.seismograph.valence;
-  const bal = result.payload.balance.valence;
-  const sfd = result.payload.sfd.sfd;
-  const splus = result.payload.sfd.sPlus;
-  const sminus = result.payload.sfd.sMinus;
-  const verdict = sfdVerdict(sfd);
-  
+  const val = result.payload.seismograph.valence_bounded;
+  const bal = result.payload.balance.valence_bounded;
+  const sfd = result.payload.sfd.sfd_cont;
+  const splus = result.payload.sfd.s_plus;
+  const sminus = result.payload.sfd.s_minus;
+  const verdict = result.payload.sfd.sfd_label || sfdVerdict(sfd);
+
   const channelLine = `Quake ${mag} · val ${fmtSigned(val)} · bal ${fmtSigned(bal)} · ${verdict} (SFD ${fmtSigned(sfd)}; S+ ${splus.toFixed(1)}/S− ${sminus.toFixed(1)})`;
   
   console.log(channelLine);


### PR DESCRIPTION
## Summary
- add a shared metrics helper to clamp and label valence, magnitude, volatility, and SFD readings
- update the Math Brain pipeline to emit bounded valence metadata, structured SFD blocks, driver weights, and normalized translocation provenance
- refresh the Woven Map composer, UI, and rendering utilities to consume the canonical metrics, surface vector integrity status, and keep downstream reporters aligned

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf7945b0ec832fa3a2fca93de27f3c