### PR TITLE
Switch PDF export to text-based generation and restore Poetic Brain availability

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -9,7 +9,15 @@ export const dynamic = 'force-dynamic';
 
 export default function ChatPage() {
   const ErrorBoundary = require('../../components/ErrorBoundary').default;
-  const poeticBrainEnabled = process.env.NEXT_PUBLIC_ENABLE_POETIC_BRAIN === 'true';
+  const poeticBrainEnabled = (() => {
+    const raw = process.env.NEXT_PUBLIC_ENABLE_POETIC_BRAIN;
+    if (typeof raw !== 'string') return true;
+    const normalized = raw.trim().toLowerCase();
+    if (normalized === '' || normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on') {
+      return true;
+    }
+    return false;
+  })();
   return (
     <ErrorBoundary>
       <RequireAuth>

--- a/app/math-brain/page.tsx
+++ b/app/math-brain/page.tsx
@@ -351,45 +351,190 @@ export default function MathBrainPage() {
     try { window.print(); } catch {/* noop */}
   }
 
-  // Prefer html2pdf-based export for consistent cross-browser PDF downloads
+  // Generate a text-based PDF so downstream tools (including Poetic Brain) can parse content
   async function downloadResultPDF() {
-    let wrapper: HTMLDivElement | null = null;
-    try {
-      const target = reportRef.current;
-      const html2pdf = (await import('html2pdf.js')).default;
-      const ts = new Date().toISOString().slice(0, 10);
-      const opt = {
-        margin: 0.5,
-        filename: `math-brain-report-${ts}.pdf`,
-        image: { type: 'jpeg', quality: 0.95 },
-        html2canvas: { scale: 2, useCORS: true, backgroundColor: '#0f1115' },
-        jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
-      } as const;
+    if (!result) {
+      setToast('No report available to export');
+      setTimeout(() => setToast(null), 2000);
+      return;
+    }
 
-      if (!target) {
-        await (html2pdf().from(document.body).set(opt).save());
-        return;
+    try {
+      const { PDFDocument, StandardFonts, rgb } = await import('pdf-lib');
+
+      const target = reportRef.current;
+      let renderedText = '';
+      if (target) {
+        const clone = target.cloneNode(true) as HTMLElement;
+        const printableHidden = clone.querySelectorAll('.print\\:hidden');
+        printableHidden.forEach((el) => el.remove());
+        clone.querySelectorAll('button, input, textarea, select').forEach((el) => el.remove());
+        renderedText = clone.innerText
+          .replace(/\u00a0/g, ' ')
+          .replace(/\n{3,}/g, '\n\n')
+          .trim();
       }
 
-      wrapper = document.createElement('div');
-      wrapper.style.position = 'fixed';
-      wrapper.style.top = '-9999px';
-      wrapper.style.left = '0';
-      wrapper.style.width = `${target.offsetWidth}px`;
-      wrapper.style.background = '#0f1115';
-      const clone = target.cloneNode(true) as HTMLElement;
-      clone.style.width = '100%';
-      wrapper.appendChild(clone);
-      document.body.appendChild(wrapper);
+      const reportKind = reportType === 'balance' ? 'Balance Meter' : 'Mirror';
+      const generatedAt = new Date();
+      const sections: Array<{ title: string; body: string; mode: 'regular' | 'mono' }> = [];
 
-      await (html2pdf().from(wrapper).set(opt).save());
+      if (renderedText) {
+        sections.push({ title: 'Rendered Summary', body: renderedText, mode: 'regular' });
+      }
+      sections.push({
+        title: 'Raw JSON Snapshot',
+        body: JSON.stringify(result, null, 2),
+        mode: 'mono',
+      });
+
+      const pdfDoc = await PDFDocument.create();
+      pdfDoc.setTitle(`Woven Web App — ${reportKind} Report`);
+      pdfDoc.setSubject('Math Brain geometry export');
+      pdfDoc.setAuthor('Woven Web App');
+      pdfDoc.setCreationDate(generatedAt);
+      pdfDoc.setModificationDate(generatedAt);
+
+      const regularFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
+      const boldFont = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
+      const monoFont = await pdfDoc.embedFont(StandardFonts.Courier);
+
+      const margin = 48;
+      const headerSize = 16;
+      const bodySize = 11;
+      const monoSize = 9;
+
+      let page = pdfDoc.addPage();
+      let { width, height } = page.getSize();
+      let cursorY = height - margin;
+      let maxWidth = width - margin * 2;
+
+      const ensureSpace = (needed: number) => {
+        if (cursorY - needed < margin) {
+          page = pdfDoc.addPage();
+          ({ width, height } = page.getSize());
+          maxWidth = width - margin * 2;
+          cursorY = height - margin;
+        }
+      };
+
+      const drawLine = (
+        text: string,
+        options: { font: any; size: number; color?: ReturnType<typeof rgb>; gap?: number; xOffset?: number },
+      ) => {
+        const { font, size, color = rgb(0.1, 0.1, 0.1), gap = 4, xOffset = 0 } = options;
+        ensureSpace(size + gap);
+        page.drawText(text, { x: margin + xOffset, y: cursorY, size, font, color });
+        cursorY -= size + gap;
+      };
+
+      const wrapRegular = (input: string) => {
+        const lines: string[] = [];
+        const text = input.replace(/\s+/g, ' ').trim();
+        if (!text) {
+          lines.push('');
+          return lines;
+        }
+        const words = text.split(' ');
+        let current = '';
+        for (const word of words) {
+          const candidate = current ? `${current} ${word}` : word;
+          if (regularFont.widthOfTextAtSize(candidate, bodySize) <= maxWidth) {
+            current = candidate;
+          } else {
+            if (current) lines.push(current);
+            if (regularFont.widthOfTextAtSize(word, bodySize) <= maxWidth) {
+              current = word;
+            } else {
+              let remaining = word;
+              const approxCharWidth = regularFont.widthOfTextAtSize('M', bodySize) || bodySize * 0.6;
+              const maxChars = Math.max(1, Math.floor(maxWidth / approxCharWidth));
+              while (remaining.length > 0) {
+                lines.push(remaining.slice(0, maxChars));
+                remaining = remaining.slice(maxChars);
+              }
+              current = '';
+            }
+          }
+        }
+        if (current) lines.push(current);
+        return lines;
+      };
+
+      const writeParagraph = (text: string) => {
+        const normalized = text.replace(/\r/g, '');
+        const chunks = normalized.split(/\n+/);
+        for (const chunk of chunks) {
+          const trimmed = chunk.trim();
+          if (!trimmed) {
+            ensureSpace(bodySize);
+            cursorY -= bodySize;
+            continue;
+          }
+          const wrapped = wrapRegular(trimmed);
+          for (const line of wrapped) {
+            drawLine(line, { font: regularFont, size: bodySize });
+          }
+          if (cursorY - 2 < margin) {
+            ensureSpace(bodySize);
+          }
+          cursorY -= 2;
+        }
+      };
+
+      const writeMonospace = (text: string) => {
+        const normalized = text.replace(/\r/g, '');
+        const lines = normalized.split('\n');
+        const charWidth = monoFont.widthOfTextAtSize('M', monoSize) || monoSize * 0.6;
+        const maxChars = Math.max(1, Math.floor(maxWidth / charWidth));
+        for (const raw of lines) {
+          if (!raw) {
+            ensureSpace(monoSize);
+            cursorY -= monoSize;
+            continue;
+          }
+          let remaining = raw;
+          while (remaining.length > 0) {
+            const segment = remaining.slice(0, maxChars);
+            drawLine(segment, { font: monoFont, size: monoSize, gap: 2 });
+            remaining = remaining.slice(segment.length);
+          }
+        }
+      };
+
+      drawLine(`Woven Web App · ${reportKind} Report`, { font: boldFont, size: headerSize, gap: 8 });
+      drawLine(`Generated: ${generatedAt.toLocaleString()}`, { font: regularFont, size: 10, color: rgb(0.35, 0.35, 0.35), gap: 12 });
+
+      sections.forEach((section) => {
+        drawLine(section.title, { font: boldFont, size: 13, gap: 6 });
+        if (section.mode === 'mono') {
+          writeMonospace(section.body);
+        } else {
+          writeParagraph(section.body);
+        }
+        if (cursorY - 6 < margin) {
+          ensureSpace(bodySize);
+        }
+        cursorY -= 6;
+      });
+
+      const pdfBytes = await pdfDoc.save();
+      const blob = new Blob([pdfBytes], { type: 'application/pdf' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      const stamp = generatedAt.toISOString().slice(0, 10);
+      link.href = url;
+      link.download = `math-brain-report-${stamp}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+      setToast('Downloading PDF report');
+      setTimeout(() => setToast(null), 1600);
     } catch (err) {
+      console.error('PDF export failed', err);
       setToast('Could not generate PDF');
       setTimeout(() => setToast(null), 2000);
-    } finally {
-      if (wrapper && document.body.contains(wrapper)) {
-        document.body.removeChild(wrapper);
-      }
     }
   }
 

--- a/components/HomeHero.tsx
+++ b/components/HomeHero.tsx
@@ -27,7 +27,15 @@ const authEnabled = (() => {
   }
   return true;
 })();
-const poeticBrainEnabled = process.env.NEXT_PUBLIC_ENABLE_POETIC_BRAIN === 'true';
+const poeticBrainEnabled = (() => {
+  const raw = process.env.NEXT_PUBLIC_ENABLE_POETIC_BRAIN;
+  if (typeof raw !== 'string') return true;
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === '' || normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on') {
+    return true;
+  }
+  return false;
+})();
 
 export default function HomeHero() {
   const authDisabled = !authEnabled;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,13 @@
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "dotenv": "^17.2.2",
-        "html2pdf.js": "^0.12.0",
         "jsonwebtoken": "^9.0.2",
         "jszip": "^3.10.1",
         "jwks-rsa": "^3.2.0",
         "luxon": "^3.7.2",
         "next": "14.2.32",
         "node-fetch": "^2.7.0",
+        "pdf-lib": "^1.17.1",
         "pdfjs-dist": "^5.4.149",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -1897,15 +1897,6 @@
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -3733,6 +3724,36 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
+      }
+    },
+    "node_modules/@pdf-lib/upng/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -4341,12 +4362,6 @@
         "undici-types": "~5.26.4"
       }
     },
-    "node_modules/@types/pako": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
-      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
-      "license": "MIT"
-    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -4359,13 +4374,6 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
       "license": "MIT"
-    },
-    "node_modules/@types/raf": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
-      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
@@ -4411,13 +4419,6 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
@@ -5551,15 +5552,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.3.tgz",
@@ -5810,26 +5802,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/canvg": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
-      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@types/raf": "^3.4.0",
-        "core-js": "^3.8.3",
-        "raf": "^3.4.1",
-        "regenerator-runtime": "^0.13.7",
-        "rgbcolor": "^1.0.1",
-        "stackblur-canvas": "^2.0.0",
-        "svg-pathdata": "^6.0.3"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/chai": {
       "version": "5.3.3",
@@ -6112,18 +6084,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/core-js": {
-      "version": "3.45.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
-      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/core-js-compat": {
       "version": "3.45.1",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.45.1.tgz",
@@ -6176,15 +6136,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/css-line-break": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
-      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-      "license": "MIT",
-      "dependencies": {
-        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -6501,16 +6452,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optional": true,
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dotenv": {
@@ -7452,17 +7393,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-png": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
-      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/pako": "^2.0.3",
-        "iobuffer": "^5.3.2",
-        "pako": "^2.1.0"
-      }
-    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -7488,6 +7418,7 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
@@ -8060,29 +7991,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/html2canvas": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
-      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-      "license": "MIT",
-      "dependencies": {
-        "css-line-break": "^2.1.0",
-        "text-segmentation": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/html2pdf.js": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/html2pdf.js/-/html2pdf.js-0.12.0.tgz",
-      "integrity": "sha512-UiaAxJpkNiintpAKZ94V0GTmwDSootT78f5AHw5nUjDXo+RHsJJ0aVhoccrxdWiM7Lx2cJ929ca7mAnbSt13gw==",
-      "license": "MIT",
-      "dependencies": {
-        "html2canvas": "^1.0.0",
-        "jspdf": "^3.0.0"
-      }
-    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -8238,12 +8146,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/iobuffer": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
-      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
-      "license": "MIT"
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
@@ -9659,23 +9561,6 @@
         "npm": ">=6"
       }
     },
-    "node_modules/jspdf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.2.tgz",
-      "integrity": "sha512-G0fQDJ5fAm6UW78HG6lNXyq09l0PrA1rpNY5i+ly17Zb1fMMFSmS+3lw4cnrAPGyouv2Y0ylujbY2Ieq3DSlKA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.9",
-        "fast-png": "^6.2.0",
-        "fflate": "^0.8.1"
-      },
-      "optionalDependencies": {
-        "canvg": "^3.0.11",
-        "core-js": "^3.6.0",
-        "dompurify": "^3.2.4",
-        "html2canvas": "^1.0.0-rc.5"
-      }
-    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -10624,12 +10509,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/pako": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
-      "license": "(MIT AND Zlib)"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10764,6 +10643,30 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
     "node_modules/pdfjs-dist": {
       "version": "5.4.149",
       "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.149.tgz",
@@ -10775,13 +10678,6 @@
       "optionalDependencies": {
         "@napi-rs/canvas": "^0.1.77"
       }
-    },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -11139,16 +11035,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "node_modules/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -11267,13 +11153,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -11442,16 +11321,6 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rgbcolor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
-      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
-      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.8.15"
       }
     },
     "node_modules/rimraf": {
@@ -12007,16 +11876,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/stackblur-canvas": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
-      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.14"
-      }
-    },
     "node_modules/std-env": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
@@ -12415,16 +12274,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/svg-pathdata": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
-      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -12560,15 +12409,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/text-segmentation": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
-      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "utrie": "^1.0.2"
       }
     },
     "node_modules/text-table": {
@@ -13207,15 +13047,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/utrie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
-      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-arraybuffer": "^1.0.2"
-      }
     },
     "node_modules/uuid": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
     "dotenv": "^17.2.2",
-    "html2pdf.js": "^0.12.0",
+    "pdf-lib": "^1.17.1",
     "jsonwebtoken": "^9.0.2",
     "jszip": "^3.10.1",
     "jwks-rsa": "^3.2.0",


### PR DESCRIPTION
## Summary
- replace the Math Brain PDF export with a pdf-lib based generator that preserves text content for downstream parsing
- add the pdf-lib dependency and remove the old html2pdf usage
- default Poetic Brain availability to enabled unless explicitly turned off so Google login reactivates chat access

## Testing
- npm run test:ci *(fails: requires local .env and RAPIDAPI_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa4387970832fbb58a2d780908964