### PR TITLE
Guard Raven API mirrors when chart context is missing

### DIFF
--- a/app/api/raven/route.ts
+++ b/app/api/raven/route.ts
@@ -8,6 +8,13 @@ import { stampProvenance } from '@/lib/raven/provenance';
 import { runMathBrain } from '@/lib/mathbrain/adapter';
 import { createProbe, commitProbe, scoreSession, type SessionSSTLog, type SSTTag } from '@/lib/raven/sst';
 
+const NO_CONTEXT_GUIDANCE = `I can’t responsibly read you without a chart or report context. Two quick options:
+
+• Generate Math Brain on the main page (geometry only), then click “Ask Raven” to send the report here
+• Or ask for “planetary weather only” to hear today’s field without personal mapping
+
+If you already have a JSON report, paste or upload it and I’ll proceed.`;
+
 // Minimal in-memory session store (dev only). For prod, persist per-user.
 const sessions = new Map<string, SessionSSTLog>();
 
@@ -61,14 +68,27 @@ export async function POST(req: Request) {
       return NextResponse.json({ intent, ok: true, draft, prov, climate: mb.climate ?? null, sessionId: sid, probe });
     }
 
-    // conversation
-  const prov = stampProvenance({ source: 'Conversational' });
-  // include the raw user input message so the LLM can respond naturally
-  const mergedOptions = { ...(options || {}), userMessage: typeof input === 'string' ? input : '' };
-  const draft = await renderShareableMirror({ geo: null, prov, options: mergedOptions, conversational: true });
-  const probe = createProbe(draft?.next_step || 'Take one breath', randomUUID());
-    sessions.get(sid)!.probes.push(probe);
-    return NextResponse.json({ intent, ok: true, draft, prov, sessionId: sid, probe });
+    if (intent === 'conversation') {
+      const textInput = typeof input === 'string' ? input : '';
+      const safeOptions = (options ?? {}) as Record<string, any>;
+      const contexts = Array.isArray(safeOptions.reportContexts) ? safeOptions.reportContexts : [];
+      const hasContextPayload = contexts.some(ctx => ctx && typeof ctx.content === 'string' && ctx.content.trim().length > 0);
+      const hasGeometryPayload = !!safeOptions.geo || !!safeOptions.geometry;
+      const hasReportIdentifiers = typeof safeOptions.reportId === 'string' || typeof safeOptions.reportType === 'string';
+      const hasLegitimatePayload = hasContextPayload || hasGeometryPayload || hasReportIdentifiers;
+      const wantsWeatherOnly = /\b(weather|sky today|planetary (weather|currents)|what's happening in the sky)\b/i.test(textInput);
+
+      if (!hasLegitimatePayload && !wantsWeatherOnly) {
+        return NextResponse.json({ intent, ok: false, error: NO_CONTEXT_GUIDANCE, sessionId: sid });
+      }
+
+      const prov = stampProvenance({ source: wantsWeatherOnly ? 'Conversational (Weather-only)' : 'Conversational' });
+      const mergedOptions = { ...safeOptions, userMessage: textInput, weatherOnly: wantsWeatherOnly };
+      const draft = await renderShareableMirror({ geo: null, prov, options: mergedOptions, conversational: true });
+      const probe = createProbe(draft?.next_step || 'Take one breath', randomUUID());
+      sessions.get(sid)!.probes.push(probe);
+      return NextResponse.json({ intent, ok: true, draft, prov, sessionId: sid, probe });
+    }
 
   } catch (error) {
     console.error('Raven API Error:', error);

--- a/test/raven-guard.test.js
+++ b/test/raven-guard.test.js
@@ -1,0 +1,47 @@
+/*
+ Smoke test to ensure Raven API guard prevents mirrors without context.
+ Requires: netlify dev running locally (http://localhost:8888)
+ */
+
+const fetch = require('node-fetch');
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8888';
+
+async function post(path, body) {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}: ${JSON.stringify(data)}`);
+  }
+  return data;
+}
+
+async function testRavenGuardBlocksPersonalMirror() {
+  const payload = {
+    input: 'Mirror me—what do you see in my chart?',
+    options: { reportContexts: [] }
+  };
+  const json = await post('/api/raven', payload);
+  if (json.ok) {
+    throw new Error('Expected guard to block mirror generation without context');
+  }
+  if (typeof json.error !== 'string' || !json.error.includes('chart or report context')) {
+    throw new Error('Guard guidance not returned from Raven API');
+  }
+  return 'PASS: Raven guard withheld mirror without chart context';
+}
+
+(async () => {
+  try {
+    const result = await testRavenGuardBlocksPersonalMirror();
+    console.log(result);
+    process.exit(0);
+  } catch (err) {
+    console.error('FAIL:', err.message);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add shared guard guidance to the Raven API so conversational mirrors require chart/report context or an explicit weather-only request
- stop the conversational branch from rendering mirrors when no validated payload is present and pass through weather-only provenance metadata
- add a smoke test that posts to `/api/raven` without report data and expects the guard guidance instead of a mirror

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68cfc608735c832f92c30d928c6d8ece