### PR TITLE
Fix Header JSX to avoid build failure

### DIFF
--- a/components/ChatClient.tsx
+++ b/components/ChatClient.tsx
@@ -2100,6 +2100,8 @@ function Header({
   onShowPendingReview,
   onShowHelp,
   devMode,
+  showPoeticMenu,
+  setShowPoeticMenu,
 }: {
   onFileSelect: (type: "mirror" | "balance" | "journal") => void;
   hasMirrorData: boolean;
@@ -2386,6 +2388,8 @@ function Header({
       throw error;
     }
   };
+
+  */
 
   const getReportIcon = (type: "mirror" | "balance" | "journal") => {
     switch (type) {


### PR DESCRIPTION
## Summary
- pass the showPoeticMenu state and setter into the Header component so JSX renders correctly
- close the temporary export block comment to restore valid JSX structure around the header action buttons

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0802bdd80832f9712b4242e096059