### PR TITLE
Normalize relocation summary handling for shared city lens

### DIFF
--- a/lib/relocation.ts
+++ b/lib/relocation.ts
@@ -1,9 +1,16 @@
 export type SubjectUI = {
   name?: string;
-  year: number | string; month: number | string; day: number | string; hour?: number|string|null; minute?: number|string|null;
-  city?: string; nation?: string;
-  latitude?: number|string; longitude?: number|string; timezone?: string; // IANA preferred
-  zodiac_type?: 'Tropic'|'Sidereal'|string;
+  year: number | string;
+  month: number | string;
+  day: number | string;
+  hour?: number | string | null;
+  minute?: number | string | null;
+  city?: string;
+  nation?: string;
+  latitude?: number | string;
+  longitude?: number | string;
+  timezone?: string; // IANA preferred
+  zodiac_type?: "Tropic" | "Sidereal" | string;
   houses_system_identifier?: string;
 };
 
@@ -29,11 +36,39 @@ export function needsLocation(
 // Relocation ("translocation") utilities
 // Keeps aspect + planetary geometry fixed; remaps Houses when lens applies.
 
+export type RelocationMode =
+  | "birthplace"
+  | "A_local"
+  | "B_local"
+  | "both_local"
+  | "event"
+  | "midpoint_advanced_hidden";
+
+export type RelocationScope =
+  | "off"
+  | "person_a"
+  | "person_b"
+  | "shared"
+  | "event";
+
+export interface RelocationCoordinates {
+  latitude: number | null;
+  longitude: number | null;
+  timezone: string | null;
+}
+
 export interface TranslocationContext {
-  applies: boolean;
-  current_location: string;
+  applies?: boolean;
+  method?: string;
+  mode?: string;
+  current_location?: string;
+  label?: string;
   house_system?: string;
   tz?: string;
+  timezone?: string;
+  coords?: { latitude?: number | string; longitude?: number | string; tz?: string; timezone?: string } | null;
+  coordinates?: { latitude?: number | string; longitude?: number | string; tz?: string; timezone?: string } | null;
+  zodiac_type?: string;
 }
 
 export interface NatalContext {
@@ -47,31 +82,274 @@ export interface ReportContext {
   type: string;
   natal: NatalContext;
   translocation: TranslocationContext;
+  provenance?: Record<string, any> | null;
+  relocation_mode?: string | null;
+  relocation_label?: string | null;
 }
 
 export interface RelocationSummary {
   active: boolean;
-  lens: string; // human readable (e.g. "Chicago, IL (WholeSign)")
-  disclosure: string; // short disclosure line
-  invariants: string; // reminder that planets/aspects unchanged
+  mode: RelocationMode;
+  scope: RelocationScope;
+  label: string | null;
+  status: string;
+  disclosure: string;
+  invariants: string;
+  confidence: "normal" | "low";
+  coordinates: RelocationCoordinates | null;
+  houseSystem: string | null;
+  zodiacType: string | null;
+  engineVersions: Record<string, string> | null;
+  provenance: {
+    relocation_mode: RelocationMode;
+    relocation_label: string | null;
+    coords: RelocationCoordinates | null;
+    tz: string | null;
+    house_system: string | null;
+    zodiac_type: string | null;
+    engine_versions: Record<string, string> | null;
+    confidence: "normal" | "low";
+  };
 }
 
-export function summarizeRelocation(ctx: ReportContext): RelocationSummary {
-  const t = ctx.translocation;
-  if (!t || !t.applies) {
-    return {
-      active: false,
-      lens: t?.current_location || 'Natal Base',
-      disclosure: 'Relocation OFF – natal House mapping in effect',
-      invariants: 'Planets, signs, aspects as computed from natal coordinates'
-    };
+const parseNumber = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : null;
   }
-  const lens = `${t.current_location}${t.house_system ? ' ('+t.house_system+')' : ''}`;
+  return null;
+};
+
+const normalizeRelocationMode = (
+  raw: unknown,
+  fallback: RelocationMode,
+): RelocationMode => {
+  if (!raw && raw !== 0) return fallback;
+  const token = String(raw)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_");
+  switch (token) {
+    case "a_local":
+    case "a_local_lens":
+    case "person_a_local":
+    case "alocal":
+    case "a_local_mode":
+      return "A_local";
+    case "b_local":
+    case "person_b_local":
+    case "blocal":
+    case "b_local_mode":
+      return "B_local";
+    case "both_local":
+    case "both":
+    case "shared":
+    case "shared_local":
+    case "dual_local":
+    case "same_city":
+      return "both_local";
+    case "event":
+    case "custom":
+    case "event_city":
+    case "custom_event":
+      return "event";
+    case "midpoint":
+    case "midpoint_advanced":
+    case "midpoint_advanced_hidden":
+    case "composite_midpoint":
+      return "midpoint_advanced_hidden";
+    case "birthplace":
+    case "none":
+    case "natal":
+    case "a_natal":
+    case "b_natal":
+    case "off":
+      return "birthplace";
+    default:
+      if (token.includes("midpoint")) return "midpoint_advanced_hidden";
+      if (token.includes("both") || token.includes("shared")) return "both_local";
+      if (token.includes("b_local")) return "B_local";
+      if (token.includes("a_local")) return "A_local";
+      if (token.includes("event")) return "event";
+      return fallback;
+  }
+};
+
+export const relocationActive = (mode: RelocationMode): boolean => mode !== "birthplace";
+
+const scopeFromMode = (mode: RelocationMode): RelocationScope => {
+  switch (mode) {
+    case "A_local":
+      return "person_a";
+    case "B_local":
+      return "person_b";
+    case "both_local":
+    case "midpoint_advanced_hidden":
+      return "shared";
+    case "event":
+      return "event";
+    default:
+      return "off";
+  }
+};
+
+export const relocationDisclosure = (
+  mode: RelocationMode,
+  label?: string | null,
+): string => {
+  const place = label?.trim();
+  const safe = place && place.length > 0 ? place : undefined;
+  switch (mode) {
+    case "birthplace":
+      return "Relocation: None (birthplace houses/angles).";
+    case "A_local":
+      return `Relocation on: ${safe ?? "Person A’s city"}. Houses/angles move; planets stay fixed.`;
+    case "B_local":
+      return `Relocation on: ${safe ?? "Person B’s city"}. Houses/angles move; planets stay fixed.`;
+    case "both_local":
+      return `Relocation on: ${safe ?? "Shared city for A & B"}. Houses/angles move; planets stay fixed.`;
+    case "event":
+      return `Relocation on: ${safe ?? "Event city"}. Houses/angles move; planets stay fixed.`;
+    case "midpoint_advanced_hidden":
+      return "Relocation: Midpoint (symbolic; lower confidence).";
+    default:
+      return `Relocation on: ${safe ?? "Selected city"}. Houses/angles move; planets stay fixed.`;
+  }
+};
+
+const relocationStatusLine = (
+  mode: RelocationMode,
+): string => {
+  switch (mode) {
+    case "birthplace":
+      return "Relocation is off. Houses/angles stay at birth locations.";
+    case "A_local":
+      return "Relocation on: Person A’s city. Houses/angles move; planets stay fixed.";
+    case "B_local":
+      return "Relocation on: Person B’s city. Houses/angles move; planets stay fixed.";
+    case "both_local":
+      return "Relocation on: Shared city for A & B. Houses/angles move; planets stay fixed.";
+    case "event":
+      return "Relocation on: Event city. Houses/angles move; planets stay fixed.";
+    case "midpoint_advanced_hidden":
+      return "Symbolic midpoint lens (not a real city). Lower diagnostic confidence.";
+    default:
+      return "Relocation lens active.";
+  }
+};
+
+const relocationInvariants = (mode: RelocationMode): string => {
+  if (mode === "midpoint_advanced_hidden") {
+    return "Symbolic midpoint frame. Planets stay fixed; treat as low confidence.";
+  }
+  if (mode === "birthplace") {
+    return "Planets and houses remain at birth coordinates.";
+  }
+  return "Planets stay fixed; houses/angles remap to the selected location.";
+};
+
+const firstDefined = <T>(...values: Array<T | null | undefined>): T | null => {
+  for (const value of values) {
+    if (value !== undefined && value !== null) return value;
+  }
+  return null;
+};
+
+export function summarizeRelocation(ctx: ReportContext): RelocationSummary {
+  const provenance = (ctx as any)?.provenance || (ctx as any)?.meta || {};
+  const t = ctx.translocation || (ctx as any)?.translocation || {};
+  const applies = Boolean(t?.applies ?? provenance?.relocation_mode);
+  const fallbackMode: RelocationMode = applies ? "event" : "birthplace";
+  const rawMode =
+    (ctx as any)?.relocation_mode ??
+    t?.mode ??
+    t?.method ??
+    provenance?.relocation_mode ??
+    (applies ? "event" : "birthplace");
+  const mode = normalizeRelocationMode(rawMode, fallbackMode);
+
+  const active = relocationActive(mode);
+  const label = firstDefined(
+    t?.current_location,
+    t?.label,
+    (ctx as any)?.relocation_label,
+    provenance?.relocation_label,
+  );
+
+  const coordsRaw =
+    t?.coords ??
+    t?.coordinates ??
+    provenance?.relocation_coords ??
+    provenance?.coords ??
+    null;
+
+  const latitude = parseNumber((coordsRaw as any)?.latitude ?? (coordsRaw as any)?.lat);
+  const longitude = parseNumber((coordsRaw as any)?.longitude ?? (coordsRaw as any)?.lon);
+  const timezone = firstDefined(
+    t?.tz,
+    t?.timezone,
+    (coordsRaw as any)?.timezone,
+    (coordsRaw as any)?.tz,
+    provenance?.relocation_timezone,
+    provenance?.tz,
+  );
+
+  const coordinates: RelocationCoordinates | null = active
+    ? {
+        latitude: latitude ?? null,
+        longitude: longitude ?? null,
+        timezone: timezone ?? null,
+      }
+    : null;
+
+  const houseSystem = firstDefined(
+    t?.house_system,
+    provenance?.house_system,
+    provenance?.house_system_name,
+  );
+  const zodiacType = firstDefined(t?.zodiac_type, provenance?.zodiac_type);
+
+  const engineVersions =
+    provenance?.engine_versions && typeof provenance.engine_versions === "object"
+      ? provenance.engine_versions
+      : null;
+
+  const confidence: "normal" | "low" = (() => {
+    const rawConfidence = provenance?.confidence;
+    if (typeof rawConfidence === "string") {
+      return rawConfidence.toLowerCase().includes("low") ? "low" : "normal";
+    }
+    return mode === "midpoint_advanced_hidden" ? "low" : "normal";
+  })();
+
+  const disclosure = relocationDisclosure(mode, label);
+  const status = relocationStatusLine(mode);
+  const invariants = relocationInvariants(mode);
+
   return {
-    active: true,
-    lens,
-    disclosure: `Relocation ON – Houses remapped to ${t.current_location}`,
-    invariants: 'Planetary geometry identical; only arena (House channels) shifted'
+    active,
+    mode,
+    scope: scopeFromMode(mode),
+    label: active ? (label ?? null) : null,
+    status,
+    disclosure,
+    invariants,
+    confidence,
+    coordinates,
+    houseSystem: houseSystem ?? null,
+    zodiacType: zodiacType ?? null,
+    engineVersions,
+    provenance: {
+      relocation_mode: mode,
+      relocation_label: active ? (label ?? null) : null,
+      coords: coordinates,
+      tz: coordinates?.timezone ?? null,
+      house_system: houseSystem ?? null,
+      zodiac_type: zodiacType ?? null,
+      engine_versions: engineVersions,
+      confidence,
+    },
   };
 }
 
@@ -136,4 +414,34 @@ export function deriveTimePolicy(s?: SubjectUI, choice?: 'planetary_only'|'whole
     effective_time_used: '00:00-23:59 (scan)',
     houses_suppressed: true
   };
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  const assertions: Array<[boolean, string]> = [
+    [relocationActive('birthplace') === false, 'relocationActive should be false for birthplace'],
+    [relocationActive('both_local') === true, 'relocationActive should be true for both_local'],
+    [
+      (() => {
+        const probe = summarizeRelocation({
+          type: 'probe',
+          natal: { name: 'Test', birth_date: '', birth_time: '', birth_place: '' },
+          translocation: {
+            applies: true,
+            method: 'Both_local',
+            current_location: 'Shared City',
+            tz: 'UTC',
+          },
+        });
+        return /Shared city/i.test(probe.disclosure);
+      })(),
+      'both_local disclosure should mention Shared city',
+    ],
+  ];
+  const failed = assertions.filter(([passed]) => !passed);
+  if (failed.length > 0) {
+    console.warn(
+      '[relocation] self-check failed:',
+      failed.map(([, message]) => message).join('; '),
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- extend relocation helpers to normalize modes, produce shared-city disclosures, and collect provenance metadata
- expose relocation status in ChatClient, feeding the structured payload into Raven requests and exports
- add a lightweight runtime self-check to verify relocation helpers recognize both_local cases

## Testing
- npm run test:chat-guard *(fails: request to http://localhost:8888/api/chat failed — local API not running)*

------
https://chatgpt.com/codex/tasks/task_e_68d08b4c1f18832f9d7130b8599624c2