### PR TITLE
Improve Auth0 session handling and transit payload mapping

### DIFF
--- a/app/math-brain/page.tsx
+++ b/app/math-brain/page.tsx
@@ -1088,6 +1088,10 @@ export default function MathBrainPage() {
       return;
     }
     if (!canSubmit) return;
+    if (startDate && endDate && new Date(startDate) > new Date(endDate)) {
+      setError("Transit start date must be on or before the end date.");
+      return;
+    }
     const nowTs = Date.now();
     if (nowTs - lastSubmitRef.current < 800) {
       return; // debounce rapid re-submits
@@ -1098,6 +1102,7 @@ export default function MathBrainPage() {
     setError(null);
     setResult(null);
     try {
+      const wantsTransits = mode !== 'NATAL_ONLY';
       const payload = {
         mode,
         personA: {
@@ -1115,6 +1120,10 @@ export default function MathBrainPage() {
           if (!timeUnknown) return 'user_provided';
           return timePolicy;
         })(),
+        ...(wantsTransits ? {
+          window: { start: startDate, end: endDate, step },
+          transits: { from: startDate, to: endDate, step },
+        } : {}),
         transitStartDate: startDate,
         transitEndDate: endDate,
         transitStep: step,

--- a/components/RequireAuth.tsx
+++ b/components/RequireAuth.tsx
@@ -66,11 +66,18 @@ export default function RequireAuth({ children }: { children: React.ReactNode })
         }
 
         const redirect_uri = getRedirectUri();
+        const authorizationParams: Record<string, any> = { redirect_uri };
+        if (config.audience) {
+          authorizationParams.audience = config.audience;
+        }
         const client = await creator({
           domain: (config.domain as string).replace(/^https?:\/\//, ''),
           clientId: config.clientId,
-          authorizationParams: { redirect_uri }
-        });
+          cacheLocation: 'localstorage',
+          useRefreshTokens: true,
+          useRefreshTokensFallback: true,
+          authorizationParams
+        } as any);
 
         // Handle callback if present
         const qs = window.location.search;


### PR DESCRIPTION
## Summary
- persist Auth0 sessions in HomeHero and RequireAuth by enabling local storage caching, refresh tokens, and audience-aware redirects
- add client-side guards for transit date ranges and include structured window/transit payloads in Math Brain submissions
- normalize incoming astrology Math Brain requests to always provide a window/transits block for the legacy handler

## Testing
- npm run test:ci *(fails: environment prerequisites missing for `.env` and `RAPIDAPI_KEY`)*

------
https://chatgpt.com/codex/tasks/task_e_68d0a3b8576c832fa68141076b364e8c