### PR TITLE
Fix Both_local relocation handling and tests

### DIFF
--- a/app/math-brain/page.tsx
+++ b/app/math-brain/page.tsx
@@ -2202,6 +2202,9 @@ export default function MathBrainPage() {
 
                   </select>
                   <p className="mt-1 text-xs text-slate-400">Relocation remaps houses/angles only; planets stay fixed. Choose the lens allowed for this report type.</p>
+                  {translocation === 'BOTH_LOCAL' && (
+                    <p className="mt-1 text-xs text-emerald-300">Houses for both Person A and Person B are recalculated from the relocation coordinates when you choose Relocate Both (A + B).</p>
+                  )}
                   <p className="mt-1 text-xs text-slate-500">Midpoint relocation is reserved for Relational Balance. Composite mode above still creates the midpoint chart.</p>
                   {relocationStatus.notice && (
                     <p className="mt-1 text-xs text-amber-400">{relocationStatus.notice}</p>

--- a/lib/server/astrology-mathbrain.js
+++ b/lib/server/astrology-mathbrain.js
@@ -73,6 +73,7 @@ const RELOCATION_FOOTNOTE_LABELS = {
   A_natal: 'Relocation mode: A_natal (houses not recalculated, by design).',
   B_local: 'Relocation mode: B_local (houses recalculated).',
   B_natal: 'Relocation mode: B_natal (houses not recalculated, by design).',
+  Both_local: 'Relocation mode: Both_local (houses recalculated).',
   Midpoint: 'Relocation mode: Midpoint (synthetic shared frame, houses recalculated).',
   Custom: 'Relocation mode: Custom (houses recalculated).'
 };
@@ -185,6 +186,10 @@ function deriveRelocationDetail(relocationMode, relocationAppliedA, relocationAp
       setMode('person_a', 'A_natal', relocationAppliedA && mode === 'B_local' ? relocationAppliedA : false);
       if (hasPersonB) setMode('person_b', 'B_local', relocationAppliedB);
       break;
+    case 'Both_local':
+      setMode('person_a', 'A_local', relocationAppliedA);
+      if (hasPersonB) setMode('person_b', 'B_local', relocationAppliedB);
+      break;
     case 'B_natal':
       if (hasPersonB) setMode('person_b', 'B_natal', relocationAppliedB);
       setMode('person_a', 'A_natal', relocationAppliedA);
@@ -278,6 +283,50 @@ function normalizeRelocationMode(mode) {
   if (['custom', 'manual', 'user'].includes(lower)) return 'Custom';
   if (['midpoint', 'mid-point'].includes(lower)) return 'Midpoint';
   return token;
+}
+
+function normalizeTranslocationBlock(raw) {
+  if (raw === null || raw === undefined) return null;
+
+  const coerceBoolean = (value) => {
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'number') {
+      if (!Number.isFinite(value)) return undefined;
+      return value !== 0;
+    }
+    if (typeof value === 'string') {
+      const token = value.trim().toLowerCase();
+      if (!token) return undefined;
+      if (['false', '0', 'no', 'off', 'none', 'natal'].includes(token)) return false;
+      if (['true', '1', 'yes', 'on', 'apply', 'applies'].includes(token)) return true;
+    }
+    return undefined;
+  };
+
+  if (typeof raw === 'string') {
+    const method = normalizeRelocationMode(raw);
+    if (!method) return null;
+    const applies = !['none', 'A_natal', 'B_natal'].includes(method);
+    return { applies, method };
+  }
+
+  if (typeof raw === 'object') {
+    const block = { ...raw };
+    const methodCandidate = block.method || block.mode || block.selection || block.type || block.lens;
+    const method = normalizeRelocationMode(methodCandidate);
+    if (method) block.method = method;
+    const coercedApplies = coerceBoolean(block.applies);
+    if (coercedApplies !== undefined) {
+      block.applies = coercedApplies;
+    } else if (method) {
+      block.applies = !['none', 'A_natal', 'B_natal'].includes(method);
+    } else {
+      block.applies = false;
+    }
+    return block;
+  }
+
+  return null;
 }
 
 function verdictFromSfd(value) {
@@ -2868,7 +2917,8 @@ async function processMathbrain(event) {
     const transitA_raw = body.transit_subject || personA;
     const transitB_raw = body.transit_subject_B || body.second_transit_subject || personB;
 
-    const translocationBlock = body.translocation || body.context?.translocation || null;
+    const translocationRaw = body.translocation || body.context?.translocation || null;
+    const translocationBlock = normalizeTranslocationBlock(translocationRaw);
     const aLocal = body.personA?.A_local || body.subjectA?.A_local || body.A_local || null;
     const bLocal = body.personB?.B_local || body.B_local || null;
     const fallbackModeToken = normalizeRelocationMode(
@@ -2884,6 +2934,7 @@ async function processMathbrain(event) {
 
     if (relocationMode === 'Midpoint') {
       return { statusCode: 400, body: JSON.stringify({ code:'RELOCATION_UNSUPPORTED', error:'Midpoint relocation is not supported for this protocol. Use A_local, B_local, or Both_local.', errorId: generateErrorId() }) };
+    }
 
     const reportContextMode = (body.context?.mode || '').toString().toLowerCase();
     const isMirrorReport = reportContextMode === 'mirror';
@@ -2907,6 +2958,7 @@ async function processMathbrain(event) {
         if (hasPersonB) {
           allowedMirror.add('B_local');
           allowedMirror.add('B_natal');
+          allowedMirror.add('Both_local');
         }
         return allowedMirror.has(guardMode) ? null : `Relocation mode ${relocationMode} is not valid for Mirror reports.`;
       }
@@ -2921,6 +2973,7 @@ async function processMathbrain(event) {
         allowedBalance.add('B_local');
         allowedBalance.add('B_natal');
         allowedBalance.add('Midpoint');
+        allowedBalance.add('Both_local');
       }
       return allowedBalance.has(guardMode) ? null : `Relocation mode ${relocationMode} is not valid for Balance reports.`;
     })();
@@ -3067,6 +3120,8 @@ async function processMathbrain(event) {
         if (transitB) transitB = { ...transitB, latitude: loc.lat, longitude: loc.lon, timezone: tz };
         relocationCoords = { lat: loc.lat, lon: loc.lon, tz };
         relocationApplied = true;
+        relocationAppliedA = true;
+        if (transitB) relocationAppliedB = true;
         if (!relocationLabel) relocationLabel = translocationBlock?.current_location || loc.label || null;
       } catch {
         return { statusCode: 400, body: JSON.stringify({ code:'TZ_LOOKUP_FAIL', error:'Could not resolve Both_local timezone', errorId: generateErrorId() }) };
@@ -3223,6 +3278,9 @@ async function processMathbrain(event) {
     }
 
     const relocationModesMentioned = new Set();
+    if (relocationMode && relocationMode !== 'none') {
+      relocationModesMentioned.add(relocationMode);
+    }
     let fallbackNoted = false;
     Object.values(relocationDetail).forEach(entry => {
       if (!entry) return;
@@ -3249,7 +3307,7 @@ async function processMathbrain(event) {
 
     // Attach translocation (relocation) context from request if provided (data-only)
     try {
-      const tl = body.translocation || body.context?.translocation || null;
+      const tl = normalizeTranslocationBlock(translocationRaw);
       if (tl || relocationMode !== 'none') {
         const explicitMode = relocationMode !== 'none' ? relocationMode : null;
         const normalizedMethod = explicitMode || normalizeRelocationMode(tl?.method) || null;
@@ -3283,7 +3341,8 @@ async function processMathbrain(event) {
           method: ctxMethod,
           house_system: houseSystem,
           tz: normalizedTz,
-          requested_tz: normalizedTz
+          requested_tz: normalizedTz,
+          houses_basis: ctxApplies ? 'relocation' : 'natal'
         };
         if (currentLocation) ctx.current_location = currentLocation;
         if (coordsBlock) ctx.coords = coordsBlock;
@@ -4127,7 +4186,6 @@ async function processMathbrain(event) {
     return { statusCode: 200, body: JSON.stringify(safeResult) };
   }
 
-}
 
 exports.handler = async function(event) {
   try {


### PR DESCRIPTION
## Summary
- normalize incoming translocation payloads so Both_local relocation applies to both participants and add relocation metadata, including houses_basis and updated footnotes
- allow Both_local in relocation guards, record relocation detail for both charts, and ensure relocation-applied flags are set for shared frames
- surface a UI helper explaining that Relocate Both recalculates houses for Person A and B
- extend the math brain tests to cover Both_local relocation objects and string tokens while aligning expected error codes

## Testing
- `node test/astrology-mathbrain.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d0c10eaeec832f879d6d3b8eea4dce