### PR TITLE
Fix Raven report context handling and guard copy

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -311,30 +311,16 @@ export async function POST(req: NextRequest){
     const climate = undefined;
 
     const astroseekReference = referencesAstroSeekWithoutGeometry(text);
-    const greetings = astroseekReference
-      ? [
-        'I see the AstroSeek export—one more bridge and we can go deep…',
-        'With you. Let’s pull that AstroSeek file all the way through first…'
-      ]
-      : [
-        'With you—before we dive in…',
-        'Here with you. One small setup step first…',
-        'Holding your question—let’s get the ground right…'
-      ];
-    const shapedIntro = shapeVoice(greetings[Math.floor(Math.random()*greetings.length)], {hook, climate, section:'mirror'}).split(/\n+/)[0];
-    const guidance = astroseekReference ? ASTROSEEK_REFERENCE_GUIDANCE : NO_CONTEXT_GUIDANCE;
-
     const guardCopy = buildNoContextGuardCopy();
-    const shapedIntro = shapeVoice(guardCopy.picture, {hook, climate, section:'mirror'}).split(/\n+/)[0];
-
-
-If you already have a JSON report—it’s the export file AstroSeek gives you—paste or upload it here and I’ll keep going.`.trim();
-
-
+    const introPicture = astroseekReference
+      ? 'I see the AstroSeek export—one more bridge and we can go deep…'
+      : guardCopy.picture;
+    const shapedIntro = shapeVoice(introPicture, {hook, climate, section:'mirror'}).split(/\n+/)[0];
+    const guardGuidance = astroseekReference ? ASTROSEEK_REFERENCE_GUIDANCE : guardCopy.guidance;
 
     const responseBody = new ReadableStream<{ }|Uint8Array>({
       async start(controller){
-        controller.enqueue(encode({climate, hook, delta: shapedIntro+"\n\n"+guardCopy.guidance}));
+        controller.enqueue(encode({climate, hook, delta: shapedIntro+"\n\n"+guardGuidance}));
         controller.close();
       }
     });

--- a/app/api/raven/route.ts
+++ b/app/api/raven/route.ts
@@ -7,18 +7,11 @@ import { renderShareableMirror } from '@/lib/raven/render';
 import { stampProvenance } from '@/lib/raven/provenance';
 import { runMathBrain } from '@/lib/mathbrain/adapter';
 import { createProbe, commitProbe, scoreSession, type SessionSSTLog, type SSTTag } from '@/lib/raven/sst';
-
-  NO_CONTEXT_GUIDANCE,
+import {
   ASTROSEEK_REFERENCE_GUIDANCE,
   referencesAstroSeekWithoutGeometry
 } from '@/lib/raven/guards';
-
 import { buildNoContextGuardCopy } from '@/lib/guard/no-context';
-
-
-If you already have a JSON report—it’s the export file AstroSeek gives you—paste or upload it here and I’ll keep going.`;
-
-
 
 // Minimal in-memory session store (dev only). For prod, persist per-user.
 const sessions = new Map<string, SessionSSTLog>();
@@ -123,19 +116,11 @@ export async function POST(req: Request) {
       const prov = stampProvenance({ source: 'Conversational Guard' });
       const guardCopy = buildNoContextGuardCopy();
       const guardDraft = {
-
-        picture: 'With you—before we dive in…',
-        feeling: 'I need a chart or report context to mirror accurately.',
-        container: 'Option 1 · Generate Math Brain on the main page, then click “Ask Raven.”',
-        option: 'Option 2 · Ask for “planetary weather only” to hear today’s field without personal mapping.',
-        next_step: 'If you already have a JSON report—it’s the export file AstroSeek gives you—paste or upload it here and I’ll keep going.'
-
         picture: guardCopy.picture,
         feeling: guardCopy.feeling,
         container: guardCopy.container,
         option: guardCopy.option,
         next_step: guardCopy.next_step
-
       };
       return NextResponse.json({ intent, ok: true, guard: true, guidance: guardCopy.guidance, draft: guardDraft, prov, sessionId: sid });
     }


### PR DESCRIPTION
## Summary
- ensure the chat client sends newly uploaded report contexts immediately by allowing `analyzeReportContext` to accept an explicit list and passing the combined contexts from the upload handler
- clean up the missing-context guard in both chat and raven routes to rely on `buildNoContextGuardCopy`, keeping AstroSeek-specific messaging intact

## Testing
- npm run build
- npm run test:chat-guard *(fails: local Raven API endpoint not running in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c5e40294832f86fa1f3d4285fe1f