### PR TITLE
Handle uploaded report JSON in Raven API

### DIFF
--- a/components/ChatClient.tsx
+++ b/components/ChatClient.tsx
@@ -255,7 +255,7 @@ function formatClimate(
 
 const INTENT_TOAST: Record<Intent, string> = {
   geometry: "Chart detected — parsing as geometry",
-  report: "Report request detected — running Math Brain handoff",
+  report: "Report lane active — Math Brain context ready",
   conversation: "Conversation lane active",
 };
 

--- a/test/raven-report-upload.test.ts
+++ b/test/raven-report-upload.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest';
+import { POST as ravenPost } from '@/app/api/raven/route';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('Raven report upload handling', () => {
+  test('acknowledges uploaded Woven JSON reports without failing', async () => {
+    const samplePath = join(
+      process.cwd(),
+      'Sample Output',
+      'relational_balance_meter_DH_Stephie_2025-09.json'
+    );
+    const jsonPayload = readFileSync(samplePath, 'utf8');
+
+    const body = {
+      action: 'generate',
+      input: jsonPayload,
+      options: {
+        reportType: 'balance',
+        reportId: 'sample-report',
+        reportContexts: [
+          {
+            id: 'sample-report',
+            type: 'balance',
+            name: 'Sample Balance Report',
+            summary: 'Demo upload for Poetic Brain logging.',
+            content: jsonPayload,
+          },
+        ],
+      },
+    };
+
+    const req = new Request('http://localhost/api/raven', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    const res = await ravenPost(req);
+    expect(res.status).toBe(200);
+
+    const payload = await res.json();
+    expect(payload.ok).toBe(true);
+    expect(payload.intent).toBe('report');
+    expect(payload.prov?.source).toBe('Uploaded JSON Report');
+    expect(payload.draft?.picture).toContain('DH Cross');
+    expect(payload.error).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add defensive helpers so the Raven API can recognise uploaded Woven JSON reports and reply with a mirrored summary instead of 500s
- persist a probe with the stored climate text and reuse Math Brain provenance for the upload acknowledgement
- tweak the report-lane toast copy and cover the upload flow with a focused vitest

## Testing
- npm test
- npx vitest run test/raven-report-upload.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d115c7b09c832fa470551cec0d0557