### PR TITLE
Adjust MirrorVoice baseline handling

### DIFF
--- a/poetic-brain/src/index.ts
+++ b/poetic-brain/src/index.ts
@@ -126,8 +126,36 @@ function formatHooksLine(hooks: HookObject[]): string {
   return items.join(' | ');
 }
 
+function hasActivationData(payload: InputPayload): boolean {
+  const hasTransits = Array.isArray(payload.transits) && payload.transits.length > 0;
+  const seismo = payload.seismograph;
+  const hasSeismograph = !!(
+    seismo &&
+    (num(seismo.magnitude) !== undefined ||
+      num(seismo.valence_bounded) !== undefined ||
+      num(seismo.valence) !== undefined ||
+      num(seismo.volatility) !== undefined ||
+      typeof seismo.valence_label === 'string')
+  );
+  return hasTransits || hasSeismograph;
+}
+
 function buildMirrorVoice(payload: InputPayload): string {
   const hooks = normalizeHooks(payload.hooks);
+  if (!hasActivationData(payload)) {
+    const lines: string[] = [];
+    const baseline = payload.constitutionalClimate?.trim();
+    if (baseline) {
+      lines.push(baseline);
+    } else {
+      lines.push('Baseline reflection: no current activation data supplied.');
+    }
+    if (hooks.length) {
+      lines.push(`Baseline Hooks — ${formatHooksLine(hooks)}`);
+    }
+    return lines.join('\n');
+  }
+
   const s = seismographSummary(payload);
   const lines: string[] = [];
   // FIELD → MAP → VOICE

--- a/poetic-brain/test/generateSection.test.ts
+++ b/poetic-brain/test/generateSection.test.ts
@@ -6,4 +6,14 @@ describe('generateSection', () => {
     const result = generateSection('MirrorVoice', payload);
     expect(typeof result).toBe('string');
   });
+
+  it('falls back to baseline reflection when no activation data is provided', () => {
+    const payload = {
+      constitutionalClimate: 'Baseline steady-state: hold your center.',
+    };
+    const result = generateSection('MirrorVoice', payload);
+    expect(result).toContain('Baseline steady-state: hold your center.');
+    expect(result).not.toMatch(/Climate:/);
+    expect(result).not.toMatch(/symbolic weather/i);
+  });
 });


### PR DESCRIPTION
## Summary
- guard MirrorVoice climate and symbolic weather phrasing behind activation data checks
- add baseline fallback that leans on constitutional climate when transits/seismograph data are absent
- cover the no-activation path with a unit test to ensure weather metaphors are omitted

## Testing
- npx jest poetic-brain/test/generateSection.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d1d260e2ac832f91f95c744e64630c