### PR TITLE
Respect activation data before invoking MirrorVoice weather language

### DIFF
--- a/poetic-brain/src/index.ts
+++ b/poetic-brain/src/index.ts
@@ -142,37 +142,35 @@ function hasActivationData(payload: InputPayload): boolean {
 
 function buildMirrorVoice(payload: InputPayload): string {
   const hooks = normalizeHooks(payload.hooks);
+  const baseline = payload.constitutionalClimate?.trim();
+  const blueprintLine = baseline
+    ? `Blueprint — ${baseline}`
+    : 'Blueprint — Baseline reflection unavailable; rely on lived experience.';
+
   if (!hasActivationData(payload)) {
-    const lines: string[] = [];
-    const baseline = payload.constitutionalClimate?.trim();
-    if (baseline) {
-      lines.push(baseline);
-    } else {
-      lines.push('Baseline reflection: no current activation data supplied.');
-    }
-    if (hooks.length) {
-      lines.push(`Baseline Hooks — ${formatHooksLine(hooks)}`);
-    }
+    const lines: string[] = [
+      blueprintLine,
+      'Current Mode — No activation data supplied; holding to the natal baseline.',
+      `Baseline Hooks — ${formatHooksLine(hooks)}`,
+      'Reflection — Map, not mandate: integrate what resonates and release the rest.',
+    ];
     return lines.join('\n');
   }
 
   const s = seismographSummary(payload);
-  const lines: string[] = [];
-  // FIELD → MAP → VOICE
-  // FIELD: climate headline
-  if (payload.climateLine && payload.climateLine.trim().length > 0) {
-    lines.push(payload.climateLine.trim());
-  } else {
-    lines.push(`Climate: ${s.headline}.`);
-  }
-  // MAP: seismograph summary
-  lines.push(`Seismograph — ${s.details}.`);
-  // MAP: Hook Stack
-  lines.push(`Hook Stack — ${formatHooksLine(hooks)}`);
-  // VOICE: narrative synthesis, agency-preserving
-  lines.push(
-    'Map, not mandate: treat this as symbolic weather. If it lands, log it; if not, discard and proceed.'
-  );
+  const weatherDescriptor =
+    payload.climateLine && payload.climateLine.trim().length > 0
+      ? payload.climateLine.trim()
+      : `Current atmosphere leans ${s.headline}.`;
+  const hookSummary = formatHooksLine(hooks);
+  const tensionParts: string[] = [`Seismograph — ${s.details}.`, `Hooks — ${hookSummary}`];
+
+  const lines: string[] = [
+    blueprintLine,
+    `Weather — ${weatherDescriptor}`,
+    `Tensions — ${tensionParts.join(' · ')}`,
+    'Reflection — Map, not mandate: treat this as symbolic weather. If it lands, log it; if not, discard and proceed.',
+  ];
   return lines.join('\n');
 }
 

--- a/poetic-brain/test/generateSection.test.ts
+++ b/poetic-brain/test/generateSection.test.ts
@@ -12,8 +12,29 @@ describe('generateSection', () => {
       constitutionalClimate: 'Baseline steady-state: hold your center.',
     };
     const result = generateSection('MirrorVoice', payload);
-    expect(result).toContain('Baseline steady-state: hold your center.');
+    expect(result).toContain('Blueprint — Baseline steady-state: hold your center.');
+    expect(result).toContain('Current Mode — No activation data supplied; holding to the natal baseline.');
+    expect(result).toContain('Reflection — Map, not mandate: integrate what resonates and release the rest.');
     expect(result).not.toMatch(/Climate:/);
     expect(result).not.toMatch(/symbolic weather/i);
+  });
+
+  it('includes symbolic weather language when activation data is present', () => {
+    const payload = {
+      constitutionalClimate: 'Core tone: steady fire with soft edges.',
+      climateLine: 'Weather front: charged conversations ready to crack open.',
+      transits: [{}],
+      seismograph: {
+        magnitude: 2.3,
+        valence: 0.4,
+        volatility: 0.6,
+      },
+      hooks: ['Venus square Mars'],
+    };
+    const result = generateSection('MirrorVoice', payload);
+    expect(result).toContain('Blueprint — Core tone: steady fire with soft edges.');
+    expect(result).toContain('Weather — Weather front: charged conversations ready to crack open.');
+    expect(result).toMatch(/Tensions —/);
+    expect(result).toMatch(/symbolic weather/i);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     environment: 'node',
     globals: true,
     testTimeout: 5000,
-    include: ['test/**/*.test.ts'],
+    include: ['test/**/*.test.ts', 'poetic-brain/test/**/*.test.ts'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- restructure MirrorVoice so baseline requests stay in blueprint mode and skip symbolic weather phrasing
- keep activation flows layered through blueprint, weather, tensions, and reflection messaging
- extend Poetic Brain Vitest coverage and include its test suite in the shared runner

## Testing
- npm run test:vitest:run

------
https://chatgpt.com/codex/tasks/task_e_68d1afb47a88832fa6db817cb5b58a9a