### PR TITLE
Clarify JSON export guidance in guard messaging

### DIFF
--- a/lib/guard/no-context.ts
+++ b/lib/guard/no-context.ts
@@ -53,10 +53,10 @@ const optionSets: OptionSet[] = [
 ];
 
 const nextSteps = [
-  'If you already have a JSON report, upload or paste it and I’ll continue.',
-  'Already sitting on a JSON report? Drop it here and I’ll move forward.',
-  'Have the JSON report handy? Bring it in and I can keep going.',
-  'When the JSON report is in, I can pick up the mirror right away.'
+  'If you already have the JSON export file—the download from Math Brain or AstroSeek—upload or paste it and I’ll continue.',
+  'Already sitting on the JSON export file—the download from Math Brain or AstroSeek? Drop it here and I’ll move forward.',
+  'Have that JSON export file—the download from Math Brain or AstroSeek—handy? Bring it in and I can keep going.',
+  'Once the JSON export file—the download from Math Brain or AstroSeek—is here, I can pick up the mirror right away.'
 ] as const;
 
 function pick<T>(items: readonly T[], rng: RandomSource): T {

--- a/lib/raven/guards.ts
+++ b/lib/raven/guards.ts
@@ -3,11 +3,11 @@ export const NO_CONTEXT_GUIDANCE = `I can’t responsibly read you without a cha
 • Generate Math Brain on the main page (geometry only), then click “Ask Raven” to send the report here
 • Or ask for “planetary weather only” to hear today’s field without personal mapping
 
-If you already have a JSON report, paste or upload it and I’ll proceed.`;
+If you already have the JSON export file—the download from Math Brain or AstroSeek—paste or upload it and I’ll proceed.`;
 
 export const ASTROSEEK_REFERENCE_GUIDANCE = `I hear you mentioning an AstroSeek export. To bring it in:
 
-• Click “Upload report” and drop the AstroSeek download (JSON or text)
+• Click “Upload report” and drop the AstroSeek download—the JSON export file with your geometry
 • Or open the export and copy/paste the entire table or text here
 
 Once that geometry is included, I can mirror you accurately.`;

--- a/test/chat-guard.test.js
+++ b/test/chat-guard.test.js
@@ -28,7 +28,10 @@ async function testNoChartNoPersonalReading() {
   const text = await post('/api/chat', payload);
   // Expect guard guidance (from route.ts guidance string)
   const containsCorePhrases = text.includes('Generate Math Brain') && text.includes('planetary weather only');
-  const mentionsJsonHelp = /export file/i.test(text) && /astroseek/i.test(text);
+  const mentionsJsonHelp =
+    /json export file/i.test(text) &&
+    /download from math brain or astroseek/i.test(text) &&
+    /astroseek/i.test(text);
   if (!containsCorePhrases || !mentionsJsonHelp) {
     throw new Error('Guard text not found in response (missing AstroSeek JSON export guidance)');
   }

--- a/test/raven-guard.test.js
+++ b/test/raven-guard.test.js
@@ -70,7 +70,9 @@ async function testRavenGuardWithoutContext() {
   }
   const guidance = String(data.guidance);
   const containsCorePhrases = guidance.includes('Generate Math Brain') && guidance.includes('planetary weather only');
-  const mentionsJsonHelp = /export file/i.test(guidance) && /astroseek/i.test(guidance);
+  const mentionsJsonHelp =
+    /json export file/i.test(guidance) &&
+    /download from math brain or astroseek/i.test(guidance);
   if (!containsCorePhrases || !mentionsJsonHelp) {
     throw new Error('Expected guard guidance missing export instructions for the AstroSeek JSON report');
   }
@@ -119,7 +121,8 @@ async function testConversationGuard() {
     'i can’t responsibly read you without a chart or report context',
     'generate math brain',
     'planetary weather only',
-    'export file',
+    'json export file',
+    'download from math brain or astroseek',
     'astroseek',
   ];
 


### PR DESCRIPTION
## Summary
- refresh the no-context guard copy so next steps describe the JSON export download from Math Brain or AstroSeek
- update Raven guard guidance to echo the new plain-language AstroSeek instructions
- adjust chat and raven guard smoke tests to look for the new phrasing while still verifying the AstroSeek mention

## Testing
- npm test -- __tests__/astroseek-guard.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d30c9755b0832f8f942b43d21fa238