### PR TITLE
Expand AstroSeek guard coverage

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -305,12 +305,12 @@ export async function POST(req: NextRequest){
   // Detect if user is asking for specific personal astrological readings/analysis
   const wantsPersonalReading = /\b(my chart|my birth|personal reading|mirror|balance meter|read me|analyze me|what do you see in me|my aspects|my placements|my transits)\b/i.test(text);
 
-  // MODIFIED GATE: Only block personal astrological readings without chart context, allow general conversation
-  if (!hasAnyReportContext && wantsPersonalReading && !wantsWeatherOnly) {
+  const astroseekReference = referencesAstroSeekWithoutGeometry(text);
+
+  // MODIFIED GATE: Block personal readings or AstroSeek references without chart context, allow general conversation or weather-only
+  if (!hasAnyReportContext && !wantsWeatherOnly && (wantsPersonalReading || astroseekReference)) {
     const hook = pickHook(text);
     const climate = undefined;
-
-    const astroseekReference = referencesAstroSeekWithoutGeometry(text);
     const guardCopy = buildNoContextGuardCopy();
     const introPicture = astroseekReference
       ? 'I see the AstroSeek export—one more bridge and we can go deep…'


### PR DESCRIPTION
## Summary
- broaden the chat no-context guard to fire when AstroSeek exports are referenced without geometry while still skipping weather-only asks
- keep the specialized AstroSeek guidance copy when that detection trips the guard
- extend the chat streaming guard tests to cover AstroSeek-only mentions so the AstroSeek guidance is asserted

## Testing
- npx jest __tests__/astroseek-guard.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d30c9589e8832fbc173b63638c0ce4