### PR TITLE
Fix Math Brain readiness for compact transit days

### DIFF
--- a/lib/server/astrology-mathbrain.js
+++ b/lib/server/astrology-mathbrain.js
@@ -85,6 +85,17 @@ const RELOCATION_FOOTNOTE_LABELS = {
 const STANDARD_BODIES = ['Sun','Moon','Mercury','Venus','Mars','Jupiter','Saturn','Uranus','Neptune','Pluto','Asc','Dsc','MC','IC'];
 const STANDARD_ASPECTS = ['conjunction','sextile','square','trine','opposition','quincunx','quintile','biquintile','semi-square','sesquiquadrate'];
 
+function resolveDayAspects(dayEntry) {
+  if (!dayEntry) return [];
+  if (Array.isArray(dayEntry)) return dayEntry;
+  if (typeof dayEntry === 'object') {
+    if (Array.isArray(dayEntry.filtered_aspects)) return dayEntry.filtered_aspects;
+    if (Array.isArray(dayEntry.aspects)) return dayEntry.aspects;
+    if (Array.isArray(dayEntry.hooks)) return dayEntry.hooks;
+  }
+  return [];
+}
+
 function buildCodebook(transitsByDate, options = {}) {
   const { includeMinors = false, includeAngles = true, maxAspectsPerDay = 40 } = options;
 
@@ -93,7 +104,8 @@ function buildCodebook(transitsByDate, options = {}) {
   const pairSet = new Set();
 
   // Collect all unique bodies, aspects, and pairs
-  Object.values(transitsByDate).forEach(aspects => {
+  Object.values(transitsByDate).forEach(dayEntry => {
+    const aspects = resolveDayAspects(dayEntry);
     aspects.forEach(aspect => {
       if (aspect.planet1) bodySet.add(aspect.planet1);
       if (aspect.planet2) bodySet.add(aspect.planet2);
@@ -118,7 +130,8 @@ function buildCodebook(transitsByDate, options = {}) {
   const patterns = [];
   const patternMap = new Map();
 
-  Object.values(transitsByDate).forEach(aspectList => {
+  Object.values(transitsByDate).forEach(dayEntry => {
+    const aspectList = resolveDayAspects(dayEntry);
     aspectList.forEach(aspect => {
       if (!aspect.planet1 || !aspect.planet2 || !aspect.aspect) return;
 
@@ -249,9 +262,30 @@ function checkBalanceReadiness(result) {
   if (!transitsByDate || Object.keys(transitsByDate).length === 0) {
     missing.push('transits');
   } else {
-    const hasDailyIndices = Object.values(transitsByDate).some(day =>
-      day.some(aspect => typeof aspect.s_plus === 'number' && typeof aspect.s_minus === 'number')
-    );
+    const hasDailyIndices = Object.values(transitsByDate).some(day => {
+      if (!day) return false;
+      if (Array.isArray(day)) {
+        return day.some(aspect => typeof aspect?.s_plus === 'number' && typeof aspect?.s_minus === 'number');
+      }
+      if (typeof day === 'object') {
+        const sfdBlock = day.sfd || day.balance || day.indices;
+        if (sfdBlock && typeof sfdBlock === 'object') {
+          const hasPlus = typeof sfdBlock.s_plus === 'number' || typeof sfdBlock.Splus === 'number';
+          const hasMinus = typeof sfdBlock.s_minus === 'number' || typeof sfdBlock.Sminus === 'number';
+          if (hasPlus && hasMinus) {
+            return true;
+          }
+          if (typeof sfdBlock.sf_diff === 'number' || typeof sfdBlock.sfd_cont === 'number') {
+            if (hasPlus || hasMinus) return true;
+          }
+        }
+        const aspects = resolveDayAspects(day);
+        if (aspects.length) {
+          return aspects.some(aspect => typeof aspect?.s_plus === 'number' && typeof aspect?.s_minus === 'number');
+        }
+      }
+      return false;
+    });
 
     if (!hasDailyIndices) {
       missing.push('s_plus', 's_minus', 'sf_diff');
@@ -4420,13 +4454,14 @@ function applyCompressionAndReadiness(result) {
       let prevCompressed = [];
 
       sortedDates.forEach((date, index) => {
-        const dayAspects = transitsByDate[date] || [];
+        const daySource = transitsByDate[date];
+        const dayAspects = resolveDayAspects(daySource);
         const compressedAspects = compressAspects(dayAspects, codebook, result.backstage.data_policy);
 
         const dayData = {
           date,
-          indices: extractDayIndices(dayAspects), // Extract s_plus, s_minus, sf_diff
-          seismograph: extractSeismographData(dayAspects), // Extract magnitude, valence, volatility
+          indices: extractDayIndices(daySource), // Extract s_plus, s_minus, sf_diff
+          seismograph: extractSeismographData(daySource), // Extract magnitude, valence, volatility
         };
 
         if (index === 0) {
@@ -4467,29 +4502,82 @@ function applyCompressionAndReadiness(result) {
   return result;
 }
 
-function extractDayIndices(aspects) {
-  // Extract s_plus, s_minus, sf_diff values from aspects
-  // Convert to fixed-point integers (*100)
+function extractDayIndices(daySource) {
+  // Extract s_plus, s_minus, sf_diff values from either compact day objects or raw aspect arrays
   const indices = { s_plus: 0, s_minus: 0, sf_diff: 0 };
+  if (!daySource) return indices;
 
+  const applyScaled = (value, key) => {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      indices[key] = Math.round(value * 100);
+      return true;
+    }
+    return false;
+  };
+
+  const tryFromBlock = (block) => {
+    if (!block || typeof block !== 'object') return;
+    const plus = typeof block.s_plus === 'number' ? block.s_plus : block.Splus;
+    const minus = typeof block.s_minus === 'number' ? block.s_minus : block.Sminus;
+    const diff = typeof block.sf_diff === 'number'
+      ? block.sf_diff
+      : (typeof block.sfd_cont === 'number' ? block.sfd_cont : undefined);
+
+    const appliedPlus = applyScaled(plus, 's_plus');
+    const appliedMinus = applyScaled(minus, 's_minus');
+
+    if (diff !== undefined) {
+      applyScaled(diff, 'sf_diff');
+    } else if (appliedPlus && appliedMinus && indices.sf_diff === 0) {
+      applyScaled(plus - minus, 'sf_diff');
+    }
+  };
+
+  if (typeof daySource === 'object' && !Array.isArray(daySource)) {
+    tryFromBlock(daySource.sfd);
+    tryFromBlock(daySource.balance);
+    tryFromBlock(daySource.indices);
+  }
+
+  const aspects = resolveDayAspects(daySource);
   aspects.forEach(aspect => {
-    if (typeof aspect.s_plus === 'number') indices.s_plus = Math.round(aspect.s_plus * 100);
-    if (typeof aspect.s_minus === 'number') indices.s_minus = Math.round(aspect.s_minus * 100);
-    if (typeof aspect.sf_diff === 'number') indices.sf_diff = Math.round(aspect.sf_diff * 100);
+    applyScaled(aspect?.s_plus, 's_plus');
+    applyScaled(aspect?.s_minus, 's_minus');
+    applyScaled(aspect?.sf_diff, 'sf_diff');
   });
 
   return indices;
 }
 
-function extractSeismographData(aspects) {
-  // Extract magnitude, valence, volatility from aspects
-  // Convert to fixed-point integers (*100)
+function extractSeismographData(daySource) {
+  // Extract magnitude, valence, volatility from compact day objects or raw aspects
   const seismograph = { magnitude: 0, valence: 0, volatility: 0 };
+  if (!daySource) return seismograph;
 
+  const applyScaled = (value, key) => {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      seismograph[key] = Math.round(value * 100);
+    }
+  };
+
+  if (typeof daySource === 'object' && !Array.isArray(daySource)) {
+    if (daySource.seismograph && typeof daySource.seismograph === 'object') {
+      applyScaled(daySource.seismograph.magnitude, 'magnitude');
+      applyScaled(daySource.seismograph.valence ?? daySource.seismograph.valence_bounded, 'valence');
+      applyScaled(daySource.seismograph.volatility, 'volatility');
+    }
+    if (daySource.balance && typeof daySource.balance === 'object') {
+      if (seismograph.valence === 0) {
+        applyScaled(daySource.balance.valence ?? daySource.balance.valence_bounded, 'valence');
+      }
+    }
+  }
+
+  const aspects = resolveDayAspects(daySource);
   aspects.forEach(aspect => {
-    if (typeof aspect.magnitude === 'number') seismograph.magnitude = Math.round(aspect.magnitude * 100);
-    if (typeof aspect.valence === 'number') seismograph.valence = Math.round(aspect.valence * 100);
-    if (typeof aspect.volatility === 'number') seismograph.volatility = Math.round(aspect.volatility * 100);
+    applyScaled(aspect?.magnitude, 'magnitude');
+    applyScaled(aspect?.valence, 'valence');
+    applyScaled(aspect?.volatility, 'volatility');
   });
 
   return seismograph;


### PR DESCRIPTION
## Summary
- normalize transit day structures so readiness and compression logic work with compact seismograph payloads
- read balance and seismograph indices from aggregated day objects before falling back to raw aspect arrays

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d351f08be8832f8695c484686810db