### PR TITLE
Remove consent gating from mirror readiness

### DIFF
--- a/lib/server/astrology-mathbrain.js
+++ b/lib/server/astrology-mathbrain.js
@@ -304,16 +304,6 @@ function checkBalanceReadiness(result) {
   };
 }
 
-function normalizeConsent(value) {
-  if (!value && value !== 0) return null;
-  const token = String(value).trim().toLowerCase();
-  if (!token) return null;
-  if (['mutual','both','bilateral','shared','double'].includes(token)) return 'mutual';
-  if (['single-sided','single','one-sided','partial','solo','solo-consent'].includes(token)) return 'single-sided';
-  if (['anon','anonymous','anonymized','privacy','blind'].includes(token)) return 'anonymized';
-  return null;
-}
-
 function extractOrb(aspect) {
   if (!aspect || typeof aspect !== 'object') return null;
   if (typeof aspect.orbit === 'number') return aspect.orbit;
@@ -606,11 +596,7 @@ function evaluateMirrorReadiness(result) {
   );
   if (!sfdReady) diagnostics.push('Support-friction delta missing');
 
-  const consentStatus = result?.context?.consent_status;
   const isRelational = Boolean(result?.person_b || result?.synastry_aspects || result?.context?.participants?.person_b);
-  if (isRelational && (!consentStatus || consentStatus === 'anonymized')) {
-    diagnostics.push('Consent not set');
-  }
 
   if (result?.person_b && !result.person_b?.details?.timezone) {
     diagnostics.push('Person B timezone missing');
@@ -633,7 +619,7 @@ const READINESS_MESSAGES = {
     SECONDARY_TIME_UNKNOWN: 'Birth time for Person B is required or choose a time policy fallback before generating a Mirror.',
     MIDPOINT_NOT_ALLOWED: 'Midpoint is for Relational Balance. Choose A_local or B_local, or switch to Balance.',
     RELATIONSHIP_DATA_MISSING: 'Relationship partner data is incomplete; load both charts to generate a relational Mirror.',
-    DEFAULT: 'Relocation/consent missing; cannot generate MAP/VOICE.'
+    DEFAULT: 'Relocation prerequisites missing; cannot generate MAP/VOICE.'
   },
   BALANCE: {
     PRIMARY_TIME_UNKNOWN: 'Balance Meter needs a known birth time or explicit time policy for Person A.',
@@ -2913,30 +2899,7 @@ async function processMathbrain(event) {
     }
   }
 
-  const consentCandidates = [
-    body.consent,
-    body.consent_status,
-    body.relationship_consent,
-    body.relationship?.consent,
-    body.relationship_context?.consent,
-    body.relationshipContext?.consent,
-    body.relationalContext?.consent
-  ];
-  const consentRawToken = consentCandidates.find(v => v !== undefined && v !== null && String(v).trim().length > 0);
-  let consentStatus = normalizeConsent(consentRawToken);
-  let consentSource = 'user_provided';
-  if (!consentStatus) {
-    consentStatus = 'anonymized';
-    consentSource = consentRawToken ? 'invalid_supplied' : 'default placeholder';
-    placeholderNotices.push('Consent status defaulted to anonymized.');
-  }
-  const consentDetail = {
-    status: consentStatus,
-    source: consentSource,
-    provenance: consentSource === 'user_provided' ? 'user_provided' : 'default placeholder',
-    confidence: consentSource === 'user_provided' ? 'high' : 'low'
-  };
-    // Use strict validator for full chart endpoints, lean for aspects-only
+  // Use strict validator for full chart endpoints, lean for aspects-only
   // Accept multiple ways of specifying mode, including saved JSON shapes
   const modeHint = body.context?.mode || body.mode || body.contextMode?.relational || body.contextMode?.solo || '';
   const modeToken = canonicalizeMode(modeHint);
@@ -3470,10 +3433,6 @@ async function processMathbrain(event) {
       },
       context: {
         mode: modeToken || 'UNKNOWN',
-        consent_status: consentStatus,
-        consent_source: consentSource,
-        consent: consentStatus,
-        consent_detail: consentDetail,
         participants: {
           person_a: identitySources.person_a,
           ...(identitySources.person_b ? { person_b: identitySources.person_b } : {})
@@ -3500,19 +3459,16 @@ async function processMathbrain(event) {
       person_a: identitySources.person_a,
       ...(identitySources.person_b ? { person_b: identitySources.person_b } : {})
     };
-    result.provenance.consent = consentDetail;
     result.provenance.relocation_detail = relocationDetail;
     result.context.relocation_detail = relocationDetail;
     if (
       identitySources.person_a?.provenance !== 'user_provided' ||
-      (identitySources.person_b && identitySources.person_b.provenance !== 'user_provided') ||
-      consentDetail.provenance !== 'user_provided'
+      (identitySources.person_b && identitySources.person_b.provenance !== 'user_provided')
     ) {
       result.provenance.confidence = 'low';
     }
 
     placeholderNotices.forEach(note => footnotes.push(note));
-    footnotes.push(`Consent status: ${consentStatus}${consentSource === 'user_provided' ? '' : ' (flagged)'}.`);
     footnotes.push(`Person A reference: ${personA.name} (${identitySources.person_a.provenance}).`);
     if (identitySources.person_b) {
       footnotes.push(`Person B reference: ${identitySources.person_b.name} (${identitySources.person_b.provenance}).`);


### PR DESCRIPTION
## Summary
- stop computing or attaching consent metadata when assembling mathbrain responses
- remove the consent requirement from mirror readiness diagnostics and update the default readiness message

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d361c101dc832f9a4efb0229068b1b