### PR TITLE
Implement AstroSeek geometry parsing and richer mirror output

### DIFF
--- a/__tests__/raven-geometry.test.ts
+++ b/__tests__/raven-geometry.test.ts
@@ -1,0 +1,59 @@
+import { parseAstroSeekBlob } from '@/lib/raven/parser';
+import { normalizeGeometry } from '@/lib/raven/normalize';
+import { renderShareableMirror } from '@/lib/raven/render';
+
+const SAMPLE_ASTROSEEK = `
+Planets at birth
+Sun 12° Aries 34' (House 1)
+Moon 18° Taurus 10' (House 10)
+Mercury 5° Aries 02' (House 1)
+Venus 22° Pisces 18' (House 12)
+Mars 28° Gemini 40' (House 3) R
+Jupiter 3° Capricorn 55' (House 10)
+Saturn 16° Aquarius 11' (House 11)
+Uranus 10° Capricorn 22' (House 10)
+Neptune 15° Capricorn 33' (House 10)
+Pluto 20° Scorpio 12' (House 7)
+Ascendant 4° Leo 20'
+Midheaven 18° Taurus 47'
+
+Aspects
+Sun Square Moon 6°44'
+Moon Trine Venus 3°52'
+Mars Opposition Jupiter 5°15'
+`;
+
+describe('AstroSeek geometry pipeline', () => {
+  test('parser extracts placements and aspects', () => {
+    const parsed = parseAstroSeekBlob(SAMPLE_ASTROSEEK);
+    expect(parsed.placements.length).toBeGreaterThan(8);
+    const sun = parsed.placements.find((p) => p.body === 'Sun');
+    const moon = parsed.placements.find((p) => p.body === 'Moon');
+    expect(sun?.sign).toBe('Aries');
+    expect(moon?.sign).toBe('Taurus');
+    const sunMoonSquare = parsed.aspects.find(
+      (a) =>
+        a.type === 'Square' &&
+        ((a.from === 'Sun' && a.to === 'Moon') || (a.from === 'Moon' && a.to === 'Sun')),
+    );
+    expect(sunMoonSquare).toBeDefined();
+  });
+
+  test('renderShareableMirror reflects parsed geometry', async () => {
+    const parsed = parseAstroSeekBlob(SAMPLE_ASTROSEEK);
+    const geo = normalizeGeometry(parsed);
+    const draft = await renderShareableMirror({ geo, prov: { source: 'AstroSeek (test)' }, options: {} });
+
+    expect(draft.picture).toMatch(/Sun Aries/i);
+    expect(draft.picture).toMatch(/Moon Taurus/i);
+    expect(draft.feeling).toMatch(/dense, deliberate weight/i);
+    expect(draft.option).toMatch(/tangible task/i);
+    expect(draft.next_step).toMatch(/Log one lived moment/i);
+
+    expect(draft.appendix.geometry_summary).toContain('Placements parsed');
+    expect(draft.appendix.primary_aspect).toMatch(/Sun Square Moon/i);
+    expect(draft.appendix.luminary_axis).toMatch(/Sun Aries/i);
+    expect(draft.appendix.provenance_source).toBe('AstroSeek (test)');
+  });
+});
+

--- a/lib/raven/normalize.ts
+++ b/lib/raven/normalize.ts
@@ -1,15 +1,139 @@
-/**
- * Placeholder function to normalize parsed geometry data into the
- * standard internal format (points, houses, drivers).
- * @param parsedData The data from a parser.
- * @returns A standardized geometry object.
- */
-export function normalizeGeometry(parsedData: Record<string, any>): Record<string, any> {
-  console.log("Normalizing geometry...");
+import type { AstroSeekParseResult, AstroSeekPlacement, AstroSeekAspect } from './parser';
+
+export interface NormalizedPlacement {
+  body: string;
+  sign?: string;
+  degree?: number;
+  house?: number;
+  retrograde?: boolean;
+  raw?: string;
+}
+
+export interface NormalizedAspect {
+  from: string;
+  to: string;
+  type: string;
+  orb?: number;
+  raw?: string;
+}
+
+export interface GeometrySummary {
+  elementTotals: Record<string, number>;
+  modalityTotals: Record<string, number>;
+  dominantElement?: string;
+  dominantModality?: string;
+  luminaries: {
+    sun?: string;
+    moon?: string;
+    ascendant?: string;
+  };
+  retrogradeBodies: string[];
+}
+
+export interface NormalizedGeometry {
+  placements: NormalizedPlacement[];
+  aspects: NormalizedAspect[];
+  summary: GeometrySummary;
+  snippet: string;
+  raw: string;
+  normalizedFrom: AstroSeekParseResult;
+}
+
+const SIGN_DETAILS: Record<string, { element: 'Fire' | 'Earth' | 'Air' | 'Water'; modality: 'Cardinal' | 'Fixed' | 'Mutable' }> = {
+  Aries: { element: 'Fire', modality: 'Cardinal' },
+  Taurus: { element: 'Earth', modality: 'Fixed' },
+  Gemini: { element: 'Air', modality: 'Mutable' },
+  Cancer: { element: 'Water', modality: 'Cardinal' },
+  Leo: { element: 'Fire', modality: 'Fixed' },
+  Virgo: { element: 'Earth', modality: 'Mutable' },
+  Libra: { element: 'Air', modality: 'Cardinal' },
+  Scorpio: { element: 'Water', modality: 'Fixed' },
+  Sagittarius: { element: 'Fire', modality: 'Mutable' },
+  Capricorn: { element: 'Earth', modality: 'Cardinal' },
+  Aquarius: { element: 'Air', modality: 'Fixed' },
+  Pisces: { element: 'Water', modality: 'Mutable' },
+};
+
+const ELEMENTS: Array<'Fire' | 'Earth' | 'Air' | 'Water'> = ['Fire', 'Earth', 'Air', 'Water'];
+const MODALITIES: Array<'Cardinal' | 'Fixed' | 'Mutable'> = ['Cardinal', 'Fixed', 'Mutable'];
+
+function normalisePlacement(placement: AstroSeekPlacement): NormalizedPlacement {
+  const { body, sign, degree, house, retrograde, raw } = placement;
+  const signClean = sign && SIGN_DETAILS[sign] ? sign : undefined;
+  const degreeRounded = typeof degree === 'number' && Number.isFinite(degree) ? Number(Number(degree).toFixed(2)) : undefined;
+  const houseValid = typeof house === 'number' && house >= 1 && house <= 12 ? house : undefined;
   return {
-    points: [],
-    houses: [],
-    drivers: [],
+    body,
+    sign: signClean,
+    degree: degreeRounded,
+    house: houseValid,
+    retrograde: retrograde === true,
+    raw,
+  };
+}
+
+function normaliseAspect(aspect: AstroSeekAspect): NormalizedAspect {
+  const { from, to, type, orb, raw } = aspect;
+  const orbRounded = typeof orb === 'number' && Number.isFinite(orb) ? Number(orb.toFixed(2)) : undefined;
+  return {
+    from,
+    to,
+    type,
+    orb: orbRounded,
+    raw,
+  };
+}
+
+function computeDominant(values: Record<string, number>): string | undefined {
+  const entries = Object.entries(values);
+  if (!entries.length) return undefined;
+  const sorted = entries.sort((a, b) => b[1] - a[1]);
+  if (sorted[0][1] === 0) return undefined;
+  const max = sorted[0][1];
+  const top = sorted.filter(([, count]) => count === max).map(([name]) => name);
+  if (top.length === 1) return top[0];
+  return top.join(' + ');
+}
+
+export function normalizeGeometry(parsedData: AstroSeekParseResult): NormalizedGeometry {
+  const placements = parsedData.placements.map(normalisePlacement);
+  const aspects = parsedData.aspects.map(normaliseAspect);
+
+  const elementTotals: Record<string, number> = Object.fromEntries(ELEMENTS.map((el) => [el, 0]));
+  const modalityTotals: Record<string, number> = Object.fromEntries(MODALITIES.map((mod) => [mod, 0]));
+
+  const luminarySigns: GeometrySummary['luminaries'] = {};
+  const retrogradeBodies: string[] = [];
+
+  for (const placement of placements) {
+    if (placement.sign) {
+      const info = SIGN_DETAILS[placement.sign];
+      if (info) {
+        elementTotals[info.element] += 1;
+        modalityTotals[info.modality] += 1;
+      }
+    }
+    if (placement.body === 'Sun') luminarySigns.sun = placement.sign;
+    if (placement.body === 'Moon') luminarySigns.moon = placement.sign;
+    if (placement.body === 'Ascendant') luminarySigns.ascendant = placement.sign;
+    if (placement.retrograde) retrogradeBodies.push(placement.body);
+  }
+
+  const summary: GeometrySummary = {
+    elementTotals,
+    modalityTotals,
+    dominantElement: computeDominant(elementTotals),
+    dominantModality: computeDominant(modalityTotals),
+    luminaries: luminarySigns,
+    retrogradeBodies,
+  };
+
+  return {
+    placements,
+    aspects,
+    summary,
+    snippet: parsedData.snippet,
+    raw: parsedData.raw,
     normalizedFrom: parsedData,
   };
 }

--- a/lib/raven/parser.ts
+++ b/lib/raven/parser.ts
@@ -1,15 +1,261 @@
 /**
- * Placeholder function to parse a raw text blob of astrological data
- * (e.g., from AstroSeek) into a structured object.
- * @param textBlob The raw string data.
- * @returns A structured representation of the geometry.
+ * Lightweight parser for AstroSeek exports. Converts the plain-text blob
+ * into placement and aspect tables that downstream renderers can work with.
  */
-export function parseAstroSeekBlob(textBlob: string): Record<string, any> {
-  console.log("Parsing AstroSeek blob...");
-  // In a real implementation, this would use regex or a parser
-  // to extract planets, signs, degrees, aspects, etc.
+export interface AstroSeekPlacement {
+  body: string;
+  sign?: string;
+  degree?: number;
+  minute?: number;
+  house?: number;
+  retrograde?: boolean;
+  raw?: string;
+}
+
+export interface AstroSeekAspect {
+  from: string;
+  to: string;
+  type: string;
+  orb?: number;
+  raw?: string;
+}
+
+export interface AstroSeekParseResult {
+  placements: AstroSeekPlacement[];
+  aspects: AstroSeekAspect[];
+  snippet: string;
+  raw: string;
+}
+
+const SIGN_ALIASES: Record<string, string> = {
+  aries: 'Aries',
+  ari: 'Aries',
+  taurus: 'Taurus',
+  tau: 'Taurus',
+  gemini: 'Gemini',
+  gem: 'Gemini',
+  cancer: 'Cancer',
+  can: 'Cancer',
+  leo: 'Leo',
+  virgo: 'Virgo',
+  vir: 'Virgo',
+  libra: 'Libra',
+  lib: 'Libra',
+  scorpio: 'Scorpio',
+  sco: 'Scorpio',
+  sagittarius: 'Sagittarius',
+  sag: 'Sagittarius',
+  capricorn: 'Capricorn',
+  cap: 'Capricorn',
+  aquarius: 'Aquarius',
+  aqu: 'Aquarius',
+  pisces: 'Pisces',
+  pis: 'Pisces',
+};
+
+const BODY_ALIASES: Record<string, string> = {
+  'sun': 'Sun',
+  'moon': 'Moon',
+  'mercury': 'Mercury',
+  'venus': 'Venus',
+  'mars': 'Mars',
+  'jupiter': 'Jupiter',
+  'saturn': 'Saturn',
+  'uranus': 'Uranus',
+  'neptune': 'Neptune',
+  'pluto': 'Pluto',
+  'chiron': 'Chiron',
+  'ceres': 'Ceres',
+  'pallas': 'Pallas',
+  'juno': 'Juno',
+  'vesta': 'Vesta',
+  'north node': 'North Node',
+  'true node': 'North Node',
+  'node': 'North Node',
+  'south node': 'South Node',
+  'lilith': 'Lilith',
+  'black moon lilith': 'Lilith',
+  'mean lilith': 'Lilith',
+  'ascendant': 'Ascendant',
+  'asc': 'Ascendant',
+  'asc.': 'Ascendant',
+  'rising': 'Ascendant',
+  'descendant': 'Descendant',
+  'dsc': 'Descendant',
+  'midheaven': 'Midheaven',
+  'mc': 'Midheaven',
+  'imum coeli': 'Imum Coeli',
+  'ic': 'Imum Coeli',
+  'part of fortune': 'Part of Fortune',
+  'fortune': 'Part of Fortune',
+};
+
+const ASPECT_ALIASES: Record<string, string> = {
+  conjunction: 'Conjunction',
+  conjunct: 'Conjunction',
+  conj: 'Conjunction',
+  opposition: 'Opposition',
+  oppose: 'Opposition',
+  opp: 'Opposition',
+  square: 'Square',
+  sq: 'Square',
+  trine: 'Trine',
+  tri: 'Trine',
+  sextile: 'Sextile',
+  sext: 'Sextile',
+  quincunx: 'Quincunx',
+  inconjunct: 'Quincunx',
+  inconj: 'Quincunx',
+};
+
+const BODY_ALIAS_ENTRIES = Object.entries(BODY_ALIASES).sort((a, b) => b[0].length - a[0].length);
+const SIGN_ALIAS_ENTRIES = Object.entries(SIGN_ALIASES).sort((a, b) => b[0].length - a[0].length);
+const BODY_PATTERN = BODY_ALIAS_ENTRIES.map(([alias]) => escapeRegExp(alias)).join('|');
+
+const ASPECT_REGEX = new RegExp(
+  `\\b(${BODY_PATTERN})\\b[^\\n]{0,40}?\\b(conjunction|conjunct|conj|opposition|oppose|opp|square|sq|trine|tri|sextile|sext|quincunx|inconjunct|inconj)\\b[^\\n]{0,40}?\\b(${BODY_PATTERN})\\b([^\\n]*)`,
+  'gi',
+);
+
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function normaliseBody(raw: string): string | undefined {
+  const key = raw.trim().toLowerCase().replace(/\s+/g, ' ');
+  return BODY_ALIASES[key];
+}
+
+function normaliseSign(raw?: string | null): string | undefined {
+  if (!raw) return undefined;
+  const key = raw.trim().toLowerCase().replace(/\s+/g, ' ');
+  return SIGN_ALIASES[key];
+}
+
+function extractDegree(segment: string): { degree?: number; minute?: number } {
+  const degreeMatch = segment.match(/(\d{1,2})\s*[°º]?\s*(\d{1,2})?/);
+  if (!degreeMatch) return {};
+  const degree = Number.parseInt(degreeMatch[1], 10);
+  const minute = degreeMatch[2] ? Number.parseInt(degreeMatch[2], 10) : undefined;
+  if (!Number.isFinite(degree)) return {};
+  return { degree, minute };
+}
+
+function extractHouse(segment: string): number | undefined {
+  const houseMatch = segment.match(/(?:house|\bH)(\d{1,2})/i);
+  if (houseMatch) {
+    const val = Number.parseInt(houseMatch[1], 10);
+    if (val >= 1 && val <= 12) return val;
+  }
+  const ordinalMatch = segment.match(/(\d{1,2})(?:st|nd|rd|th)\s+house/i);
+  if (ordinalMatch) {
+    const val = Number.parseInt(ordinalMatch[1], 10);
+    if (val >= 1 && val <= 12) return val;
+  }
+  return undefined;
+}
+
+function detectBodyFromLine(line: string): string | undefined {
+  const lower = line.toLowerCase();
+  for (const [alias, canonical] of BODY_ALIAS_ENTRIES) {
+    if (!lower.startsWith(alias)) continue;
+    const nextChar = lower.charAt(alias.length);
+    if (nextChar && /[a-z0-9]/i.test(nextChar)) {
+      continue;
+    }
+    return canonical;
+  }
+  return undefined;
+}
+
+function detectSignFromLine(line: string): string | undefined {
+  const lower = line.toLowerCase();
+  for (const [alias, canonical] of SIGN_ALIAS_ENTRIES) {
+    const index = lower.indexOf(alias);
+    if (index === -1) continue;
+    const before = index > 0 ? lower.charAt(index - 1) : '';
+    const after = lower.charAt(index + alias.length);
+    const boundaryBefore = !before || /[^a-z0-9]/i.test(before);
+    const boundaryAfter = !after || /[^a-z0-9]/i.test(after);
+    if (boundaryBefore && boundaryAfter) {
+      return canonical;
+    }
+  }
+  return undefined;
+}
+
+function extractOrb(fragment: string): number | undefined {
+  const orbMatch = fragment.match(/(\d{1,2})\s*[°º]\s*(\d{1,2})?/);
+  if (!orbMatch) return undefined;
+  const degree = Number.parseInt(orbMatch[1], 10);
+  const minute = orbMatch[2] ? Number.parseInt(orbMatch[2], 10) : 0;
+  if (!Number.isFinite(degree)) return undefined;
+  return degree + minute / 60;
+}
+
+function toDecimal(degree?: number, minute?: number): number | undefined {
+  if (degree === undefined) return undefined;
+  const deg = Number.isFinite(degree) ? degree : undefined;
+  if (deg === undefined) return undefined;
+  if (minute === undefined || !Number.isFinite(minute)) return deg;
+  return deg + minute / 60;
+}
+
+/**
+ * Parse an AstroSeek export blob into placements and aspects.
+ */
+export function parseAstroSeekBlob(textBlob: string): AstroSeekParseResult {
+  const placements: AstroSeekPlacement[] = [];
+  const seenBodies = new Set<string>();
+  const lines = textBlob.split(/\r?\n/);
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const body = detectBodyFromLine(trimmed);
+    if (body && !seenBodies.has(body)) {
+      const sign = detectSignFromLine(trimmed);
+      const vicinity = sign
+        ? trimmed.slice(Math.max(0, trimmed.toLowerCase().indexOf(sign.toLowerCase()) - 12), trimmed.length)
+        : trimmed;
+      const { degree, minute } = extractDegree(vicinity);
+      const house = extractHouse(trimmed);
+      const retrograde = /(\bR\b|retrograde)/i.test(trimmed);
+      placements.push({
+        body,
+        sign,
+        degree: toDecimal(degree, minute),
+        minute,
+        house,
+        retrograde,
+        raw: trimmed,
+      });
+      seenBodies.add(body);
+      continue;
+    }
+  }
+
+  const aspects: AstroSeekAspect[] = [];
+  const seenAspects = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = ASPECT_REGEX.exec(textBlob)) !== null) {
+    const [, fromRaw, typeRaw, toRaw, trailing] = match;
+    const from = normaliseBody(fromRaw);
+    const to = normaliseBody(toRaw);
+    const type = ASPECT_ALIASES[typeRaw.toLowerCase()] || undefined;
+    if (!from || !to || !type) continue;
+    const key = [from, type, to].sort().join('|');
+    if (seenAspects.has(key)) continue;
+    const orb = extractOrb(trailing ?? '');
+    aspects.push({ from, to, type, orb, raw: match[0].trim() });
+    seenAspects.add(key);
+  }
+
   return {
-    parsed: true,
-    content: textBlob.substring(0, 100) + "...", // Return a snippet for demo
+    placements,
+    aspects,
+    snippet: textBlob.trim().slice(0, 240),
+    raw: textBlob,
   };
 }


### PR DESCRIPTION
## Summary
- add an AstroSeek parser that extracts placements, aspects, houses, and retrograde flags from pasted chart text
- normalize parsed geometry into Woven Map summaries including element/modality dominance, luminaries, and retrograde bodies
- render geometry-driven mirrors with data-aware picture/feeling/option/next-step copy and provenance details, plus regression tests covering the new pipeline

## Testing
- npx jest __tests__/raven-geometry.test.ts --runInBand
- npx jest __tests__/astroseek-guard.test.ts --runInBand


------
https://chatgpt.com/codex/tasks/task_e_68d32f66391c832f81df408f172f2e2f