### PR TITLE
Fix chat stream height on mobile

### DIFF
--- a/components/ChatClient.tsx
+++ b/components/ChatClient.tsx
@@ -3286,6 +3286,8 @@ function Stream({
     note?: string,
   ) => void;
 }) {
+  // Rely on flex sizing so mobile Safari calculates the scrollable
+  // conversation height correctly without collapsing the stream.
   return (
     <section
       ref={containerRef}
@@ -3300,7 +3302,7 @@ function Stream({
         flexDirection: "column",
         gap: 12,
         overflow: "auto",
-        height: "100%",
+        flex: 1,
         minHeight: 0,
         WebkitOverflowScrolling: "touch",
       }}


### PR DESCRIPTION
## Summary
- ensure the chat stream uses flex sizing so the conversation remains visible on iOS Safari

## Testing
- npm run lint *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b4e69c10832f9018fe052d520d00