### PR TITLE
Add deployment metadata to home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,16 @@
 export const dynamic = 'force-dynamic';
 import HomeHero from "../components/HomeHero";
+import { buildInfo } from "../lib/buildInfo";
 
 export default function Home() {
+  const formattedTimestamp =
+    buildInfo.timestamp !== "unknown"
+      ? new Intl.DateTimeFormat("en-US", {
+          dateStyle: "medium",
+          timeStyle: "short",
+        }).format(new Date(buildInfo.timestamp))
+      : "unknown";
+
   return (
     <main className="mx-auto max-w-3xl px-6 py-16">
       <header className="text-center">
@@ -40,6 +49,10 @@ export default function Home() {
       </section>
 
       <HomeHero />
+
+      <footer className="mt-12 text-right text-xs text-slate-500">
+        <span className="font-medium text-slate-400">Deployment:</span> {buildInfo.commit} · {formattedTimestamp}
+      </footer>
     </main>
   );
 }

--- a/lib/buildInfo.ts
+++ b/lib/buildInfo.ts
@@ -1,0 +1,19 @@
+import { execSync } from "child_process";
+
+function readGitData(command: string) {
+  try {
+    return execSync(command, { stdio: ["ignore", "pipe", "ignore"] })
+      .toString()
+      .trim();
+  } catch (error) {
+    return "unknown";
+  }
+}
+
+const commit = readGitData("git rev-parse --short HEAD");
+const timestamp = readGitData("git log -1 --format=%cI");
+
+export const buildInfo = {
+  commit,
+  timestamp,
+};


### PR DESCRIPTION
## Summary
- add a build info helper that reads the current commit hash and timestamp from git
- surface the deployment metadata in a subtle footer on the home page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d827fee4cc832fb4a3ea7d57242d25