### PR TITLE
Adjust transit date defaults to single-day window

### DIFF
--- a/app/math-brain/page.tsx
+++ b/app/math-brain/page.tsx
@@ -129,11 +129,12 @@ export default function MathBrainPage() {
   const fmt = useCallback((d: Date) => d.toISOString().slice(0, 10), []);
 
   // Default date ranges differ based on whether symbolic weather (transits) are enabled
+  // - Transits default to a single-day window that users can expand as needed
+  // - Natal-only defaults to a week-long planning window
   const getDefaultDates = useCallback((withTransits: boolean) => {
     const start = fmt(today);
     if (withTransits) {
-      const end = fmt(new Date(today.getTime() + 30 * 24 * 60 * 60 * 1000));
-      return { start, end };
+      return { start, end: start };
     }
     const end = fmt(new Date(today.getTime() + 6 * 24 * 60 * 60 * 1000));
     return { start, end };


### PR DESCRIPTION
## Summary
- default the transit date range to a single-day window so start and end match by default
- document the differing defaults for transit versus natal-only modes

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d8d086aa70832faa3a9185617f6d9c