### PR TITLE
Fix relocation label usage and add snapshot typing

### DIFF
--- a/app/math-brain/page.tsx
+++ b/app/math-brain/page.tsx
@@ -88,7 +88,14 @@ const toNatalMode = (mode: ReportMode): ReportMode => {
 };
 
 // Helper functions to extract UI/UX Contract types from existing data
-function extractReportHeader(mode: ReportMode, startDate: string, endDate: string, step: string, relocationStatus: any): ReportHeader {
+function extractReportHeader(
+  mode: ReportMode,
+  startDate: string,
+  endDate: string,
+  step: string,
+  relocationStatus: any,
+  relocationLabel?: string
+): ReportHeader {
   const normalizedMode = (() => {
     switch (mode) {
       case 'NATAL_ONLY': return 'NATAL';
@@ -110,7 +117,10 @@ function extractReportHeader(mode: ReportMode, startDate: string, endDate: strin
     } : undefined,
     relocated: {
       active: relocationStatus.effectiveMode !== 'NONE',
-      label: relocationStatus.effectiveMode !== 'NONE' ? (relocLabel || undefined) : undefined
+      label:
+        relocationStatus.effectiveMode !== 'NONE'
+          ? (relocationLabel?.trim() ? relocationLabel.trim() : undefined)
+          : undefined
     }
   };
 }
@@ -470,12 +480,6 @@ export default function MathBrainPage() {
     ? { value: 'NATAL_TRANSITS' as ReportMode, label: 'Natal + Transits' }
     : { value: 'NATAL_ONLY' as ReportMode, label: 'Natal Only' };
 
-  // Extract UI/UX Contract types (computed once, passed down to children)
-  const reportHeader = useMemo(() =>
-    extractReportHeader(mode, startDate, endDate, step, relocationStatus),
-    [mode, startDate, endDate, step, relocationStatus]
-  );
-
   const weather = useMemo(() =>
     extractWeather(startDate, endDate, result),
     [startDate, endDate, result]
@@ -690,6 +694,12 @@ export default function MathBrainPage() {
 
     return { effectiveMode, notice };
   }, [includeTransits, translocation, relocationInputReady, isDyadMode, personBLocationReady]);
+
+  // Extract UI/UX Contract types (computed once, passed down to children)
+  const reportHeader = useMemo(
+    () => extractReportHeader(mode, startDate, endDate, step, relocationStatus, relocLabel),
+    [mode, startDate, endDate, step, relocationStatus, relocLabel]
+  );
 
   // If Person B is turned off while a relational mode is selected, reset to a solo mode
   useEffect(() => {

--- a/lib/ui-types.ts
+++ b/lib/ui-types.ts
@@ -19,3 +19,46 @@ export type Weather = {
 export type Blueprint = {
   thesis: string; // non-empty string; always provided
 };
+
+export type SnapshotTone = {
+  magnitude: "Low" | "Moderate" | "High";
+  valence: "Harmonious" | "Tense" | "Complex";
+  volatility: "Stable" | "Variable" | "Unstable";
+};
+
+export type SnapshotAnchor = {
+  name: string;
+  strength: number;
+  valence: "supportive" | "challenging" | "mixed";
+  benefit: string;
+  friction: string;
+};
+
+export type SnapshotHook = {
+  label: string;
+  intensity: number;
+  targetHouse: string;
+};
+
+export type SnapshotData = {
+  header: {
+    location: string;
+    dateRange: string;
+    type: "Snapshot" | "Overview";
+  };
+  tone: SnapshotTone;
+  anchors: SnapshotAnchor[];
+  hooks: SnapshotHook[];
+  topHouse: {
+    tag: string;
+    keywords: string;
+    relocated: boolean;
+  };
+  heatband?: Array<{ day: string; intensity: "light" | "medium" | "dark" }>;
+  auditFooter: {
+    anchorsCount: number;
+    hooksCount: number;
+    lens: string;
+    peaks?: string;
+  };
+};


### PR DESCRIPTION
## Summary
- pass the relocation label into the Math Brain report header so relocation badges render reliably
- add explicit snapshot-related UI contract types for Poetic Snapshot components and utilities

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8e1f67c5c832fb27ee3af70c6674f