### PR TITLE
Add mirror readiness contract header snippet to report template

### DIFF
--- a/templates/sample_8.23.25.md
+++ b/templates/sample_8.23.25.md
@@ -1,5 +1,39 @@
 # Woven Map Sample Report Template
 
+## Contract Header (Drop-in Snippet)
+Use this JSON block at the top of every generated report. It explicitly affirms when natal data and a transit window are present so Raven always renders Mirrors unless you override it manually.
+
+```json
+{
+  "contract": "clear-mirror/1.3",
+  "contract_header": {
+    "contract_valid": true,
+    "mirror_ready": true,
+    "mode": "relational",
+    "inputs_confirmed": {
+      "natal_payload": "present",
+      "transit_window": {
+        "start": "2025-09-01",
+        "end": "2025-09-30",
+        "confidence": "exact"
+      },
+      "locations": {
+        "person_a": "Philadelphia, PA, USA",
+        "person_b": "New York, NY, USA"
+      }
+    },
+    "warnings": [],
+    "errors": []
+  },
+  "status_copy": "Natal + transit inputs confirmed. Mirrors unlocked."
+}
+```
+
+**Rules for the generator**
+- Populate `mode` with `"single"`, `"relational"`, or other supported values to match the active layout.
+- Only flip `contract_valid` or `mirror_ready` to `false` when inputs are genuinely missing; keep `errors` empty when all data is confirmed.
+- Surface soft issues (like approximate birth time) inside `warnings` without blocking Mirrors.
+
 ## Natal Math (Raw)
 Placeholder table for planetary positions.
 


### PR DESCRIPTION
## Summary
- add a contract header JSON block to the sample report template so mirror generation stays enabled when data is present
- document generator rules for populating the new header without creating false invalidations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d97dc80f8c832fbf6da4edb12a2b68