### PR TITLE
Fix Poetic Brain chat height collapse when report contexts display

### DIFF
--- a/components/ChatClient.tsx
+++ b/components/ChatClient.tsx
@@ -1926,7 +1926,8 @@ export default function ChatClient() {
       style={{
         display: "flex",
         flexDirection: "column",
-        height: "100vh",
+        minHeight: "100vh",
+        height: "100%",
         maxWidth: 980,
         margin: "0 auto",
       }}


### PR DESCRIPTION
## Summary
- allow the Poetic Brain chat shell to expand beyond the viewport height so report-context banners no longer collapse the conversation stream

## Testing
- npm run lint *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68d982bd0e78832f8fe66ed52c10e375