### PR TITLE
Add visual Balance Meter capture to graphs PDF export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "dotenv": "^17.2.2",
+        "html2canvas": "^1.4.1",
         "html2pdf.js": "^0.12.1",
         "jsonwebtoken": "^9.0.2",
         "jszip": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@google/generative-ai": "^0.24.1",
     "dotenv": "^17.2.2",
     "html2pdf.js": "^0.12.1",
+    "html2canvas": "^1.4.1",
     "jsonwebtoken": "^9.0.2",
     "jszip": "^3.10.1",
     "jwks-rsa": "^3.2.0",


### PR DESCRIPTION
## Summary
- capture the rendered Balance Meter dashboard with html2canvas and embed the image alongside the existing data analysis in the graphs PDF export
- wrap the Balance Meter section with a reusable ref so the PDF job can reliably target the live dashboard before and after toggling visibility
- add the html2canvas dependency needed for client-side screenshot support

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbf90af834832fb35ba8532b204f78