### PR TITLE
Add sidereal variant support for astrology proxy

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -271,7 +271,7 @@ const API_ENDPOINTS = {
 ```javascript
 const defaultActivePoints = [
   "Sun", "Moon", "Mercury", "Venus", "Mars", "Jupiter", "Saturn",
-  "Uranus", "Neptune", "Pluto", "Mean_Node", "Chiron", 
+  "Uranus", "Neptune", "Pluto", "Mean_Node", "Chiron",
   "Ascendant", "Medium_Coeli", "Mean_Lilith", "Mean_South_Node"
 ];
 
@@ -283,6 +283,14 @@ const defaultActiveAspects = [
   { name: "sextile", orb: 5 }
 ];
 ```
+
+### Sidereal Variants
+
+- Set `includeSidereal: true` on the request body to fetch both the Tropic and Sidereal variants in a single round-trip.
+- Provide either `default_sidereal_mode` (global ayanamsa) or `sidereal_mode` on each person block—values are normalized to
+  RapidAPI's uppercase identifiers such as `LAHIRI`, `FAGAN_BRADLEY`, etc.
+- When the sidereal branch is active the service automatically normalizes any lowercase `zodiac_type` strings (`"tropical"` →
+  `"Tropic"`, `"sidereal"` → `"Sidereal"`) before proxying to the upstream API.
 
 ---
 

--- a/FORM_DATA_EXAMPLE.md
+++ b/FORM_DATA_EXAMPLE.md
@@ -163,6 +163,7 @@ Here's what the complete form data structure should look like:
     "latitude": 40.7128,
     "longitude": -74.0060,
     "zodiac_type": "Tropic",
+    "sidereal_mode": "LAHIRI",
     "timezone": "America/New_York"
   },
   "personB": {
@@ -178,6 +179,7 @@ Here's what the complete form data structure should look like:
     "latitude": 34.0522,
     "longitude": -118.2437,
     "zodiac_type": "Tropic",
+    "sidereal_mode": "LAHIRI",
     "timezone": "America/Los_Angeles"
   },
   "context": {
@@ -185,6 +187,8 @@ Here's what the complete form data structure should look like:
     "relationship_type": "partner",
     "intimacy_tier": "P3"
   },
+  "includeSidereal": true,
+  "default_sidereal_mode": "LAHIRI",
   "relocation": {
     "enabled": false
   }
@@ -192,3 +196,5 @@ Here's what the complete form data structure should look like:
 ```
 
 Use this as a reference when implementing form data validation and submission.
+
+Set `includeSidereal` to `true` to receive both the Tropic and Sidereal charts in a single response. Use `default_sidereal_mode` (or `sidereal_mode` on each person) to pick the ayanamsa used for the sidereal computation.

--- a/src/services/astrologyMathBrain.ts
+++ b/src/services/astrologyMathBrain.ts
@@ -16,6 +16,7 @@ export const AstrologyRequestSchema = z.object({
     nation: z.string().optional(),
     timezone: z.string().optional(),
     zodiac_type: z.string().optional(),
+    sidereal_mode: z.string().optional(),
   }),
   personB: z.object({
     name: z.string(),
@@ -31,6 +32,7 @@ export const AstrologyRequestSchema = z.object({
     nation: z.string().optional(),
     timezone: z.string().optional(),
     zodiac_type: z.string().optional(),
+    sidereal_mode: z.string().optional(),
   }).optional(),
   context: z.object({
     mode: z.string().optional()
@@ -44,6 +46,8 @@ export const AstrologyRequestSchema = z.object({
   orbs_profile: z.string().optional(),
   relocation_mode: z.any().optional(),
   houses_system_identifier: z.string().optional(),
+  includeSidereal: z.boolean().optional(),
+  default_sidereal_mode: z.string().optional(),
 });
 
 export type AstrologyRequest = z.infer<typeof AstrologyRequestSchema>;
@@ -64,6 +68,46 @@ export type AstrologyResponse = AstrologyResponseSuccess | AstrologyResponseErro
 // Upstream invocation (RapidAPI Astrologer)
 const UPSTREAM_URL = 'https://astrologer.p.rapidapi.com/api/v2/natal-chart';
 
+type ZodiacVariant = 'Tropic' | 'Sidereal' | null;
+
+function normalizeZodiacType(value?: string | null): 'Tropic' | 'Sidereal' | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (normalized.startsWith('sid')) return 'Sidereal';
+  if (normalized === 'sideral') return 'Sidereal';
+  if (normalized.startsWith('tro')) return 'Tropic';
+  return undefined;
+}
+
+function normalizeSiderealMode(value?: string | null): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.toUpperCase().replace(/[\s-]+/g, '_');
+}
+
+function buildVariantPayload(base: Record<string, any>, target: ZodiacVariant, defaultSidereal?: string) {
+  const payload = JSON.parse(JSON.stringify(base));
+  const defaultMode = normalizeSiderealMode(defaultSidereal);
+  (['personA', 'personB'] as const).forEach((key) => {
+    const person = payload[key];
+    if (!person) return;
+    const requestedZodiac = target ?? person.zodiac_type;
+    const normalizedZodiac = normalizeZodiacType(requestedZodiac) ?? 'Tropic';
+    person.zodiac_type = normalizedZodiac;
+    if (normalizedZodiac === 'Sidereal') {
+      const explicitMode = normalizeSiderealMode(person.sidereal_mode) || defaultMode || 'LAHIRI';
+      person.sidereal_mode = explicitMode;
+    } else {
+      if (person.sidereal_mode !== undefined) {
+        delete person.sidereal_mode;
+      }
+    }
+  });
+  return payload;
+}
+
 export async function computeAstrology(req: AstrologyRequest): Promise<AstrologyResponse> {
   const parse = AstrologyRequestSchema.safeParse(req);
   if (!parse.success) {
@@ -73,23 +117,55 @@ export async function computeAstrology(req: AstrologyRequest): Promise<Astrology
   if (!RAPIDAPI_KEY) {
     return { ok: false, status: 500, error: 'Missing RAPIDAPI_KEY' };
   }
-  try {
-    const upstream = await fetch(UPSTREAM_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-RapidAPI-Key': RAPIDAPI_KEY,
-        'X-RapidAPI-Host': 'astrologer.p.rapidapi.com'
-      },
-      body: JSON.stringify(req)
-    });
-    if (!upstream.ok) {
-      const text = await upstream.text();
-      return { ok: false, status: upstream.status, error: 'Upstream error', detail: text.slice(0, 1500) };
+  const { includeSidereal = false, default_sidereal_mode, ...baseRequest } = parse.data;
+
+  const callUpstream = async (payload: Record<string, any>): Promise<AstrologyResponse> => {
+    try {
+      const upstream = await fetch(UPSTREAM_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-RapidAPI-Key': RAPIDAPI_KEY,
+          'X-RapidAPI-Host': 'astrologer.p.rapidapi.com'
+        },
+        body: JSON.stringify(payload)
+      });
+      if (!upstream.ok) {
+        const text = await upstream.text();
+        return { ok: false, status: upstream.status, error: 'Upstream error', detail: text.slice(0, 1500) };
+      }
+      const data = await upstream.json();
+      return { ok: true, data };
+    } catch (err: any) {
+      return { ok: false, status: 500, error: 'Internal error', detail: err?.message || String(err) };
     }
-    const data = await upstream.json();
-    return { ok: true, data };
-  } catch (err: any) {
-    return { ok: false, status: 500, error: 'Internal error', detail: err?.message || String(err) };
+  };
+
+  if (!includeSidereal) {
+    const payload = buildVariantPayload(baseRequest as Record<string, any>, null, default_sidereal_mode);
+    return callUpstream(payload);
   }
+
+  const tropicalPayload = buildVariantPayload(baseRequest as Record<string, any>, 'Tropic', default_sidereal_mode);
+  const siderealPayload = buildVariantPayload(baseRequest as Record<string, any>, 'Sidereal', default_sidereal_mode);
+
+  const [tropical, sidereal] = await Promise.all([
+    callUpstream(tropicalPayload),
+    callUpstream(siderealPayload)
+  ]);
+
+  if (!tropical.ok) {
+    return tropical;
+  }
+  if (!sidereal.ok) {
+    return sidereal;
+  }
+
+  return {
+    ok: true,
+    data: {
+      tropical: tropical.data,
+      sidereal: sidereal.data
+    }
+  };
 }


### PR DESCRIPTION
## Summary
- allow sidereal ayanamsa hints on person records and add request flags for dual tropical/sidereal fetches
- normalize zodiac/sidereal options before proxying and fan out to RapidAPI when `includeSidereal` is requested
- document the new sidereal options in the API reference and form data example

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dbfda67b74832f920fc79939b314cb