### PR TITLE
Fix Auth0 redirect URI for math brain callback

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,10 +1,19 @@
 // Small shared utility for Auth0 redirect consistency
 // Send users back to home page after authentication
 
+const AUTH_CALLBACK_PATH = '/math-brain';
+
 export function getRedirectUri(): string {
   if (typeof window === 'undefined') {
     // SSR fallback: safe default path; client will compute exact origin
-    return '/';
+    return AUTH_CALLBACK_PATH;
   }
-  return window.location.origin + '/';
+
+  try {
+    return new URL(AUTH_CALLBACK_PATH, window.location.origin).toString();
+  } catch (err) {
+    // Fallback to manual concatenation if URL construction fails (very unlikely)
+    const origin = window.location.origin.replace(/\/$/, '');
+    return `${origin}${AUTH_CALLBACK_PATH}`;
+  }
 }


### PR DESCRIPTION
## Summary
- update the shared Auth0 redirect helper to return the /math-brain callback path so the SPA login uses an allowed URL
- add a defensive fallback when constructing the redirect URI in the browser

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df97a77c5c832f8ff73a995d298fe5