### PR TITLE
Improve chat viewport padding and mobile sidebar exit

### DIFF
--- a/components/ChatClient.tsx
+++ b/components/ChatClient.tsx
@@ -2810,6 +2810,14 @@ export default function ChatClient() {
                   hasMirrorData={hasMirrorData}
                 />
               </div>
+              <div className="border-t border-[var(--line)] bg-[var(--panel)] px-3 py-2">
+                <button
+                  onClick={() => setIsSidebarOpen(false)}
+                  className="w-full rounded-[10px] border border-[var(--line)] bg-[var(--soft)] px-3 py-2 text-[12px] text-[var(--text)]"
+                >
+                  ← Back to chat
+                </button>
+              </div>
             </div>
           </div>
         </>
@@ -3870,7 +3878,7 @@ function Stream({
         overscrollBehavior: "contain",
         scrollPaddingTop: scrollPadding,
         scrollPaddingBottom: scrollPadding,
-        paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 16px)",
+        paddingBottom: `calc(${scrollPadding}px + env(safe-area-inset-bottom, 0px))`,
       }}
     >
       {messages.map((m) => (


### PR DESCRIPTION
## Summary
- ensure the conversation stream reserves enough space under the sticky composer to keep full replies visible
- add a dedicated "Back to chat" control to the mobile sidebar overlay so the chat is easy to return to after opening Math Brain tools

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e396b210b0832fab172b9e3284875e