### PR TITLE
Adds a default date range to the v2Config to prevent crashes on timel…

### DIFF
--- a/app/api/astrology-mathbrain/route.ts
+++ b/app/api/astrology-mathbrain/route.ts
@@ -297,12 +297,16 @@ export async function POST(request: NextRequest) {
         return 'SYNASTRY_TRANSITS';
       })();
 
+      const today = new Date().toISOString().split('T')[0];
+      const startDate = parsedBody.window?.start || parsedBody.transits?.from;
+      const endDate = parsedBody.window?.end || parsedBody.transits?.to;
+
       const v2Config = {
         schema: 'mb-1',
         mode: v2Mode,
         step: parsedBody.window?.step || 'daily',
-        startDate: parsedBody.window?.start || parsedBody.transits?.from,
-        endDate: parsedBody.window?.end || parsedBody.transits?.to,
+        startDate: startDate || today,
+        endDate: endDate || today,
         personA: parsedBody.personA,
         personB: parsedBody.personB || null,
         translocation: parsedBody.context?.translocation || 'BOTH_LOCAL',


### PR DESCRIPTION
…ess reports.

This commit introduces a hotfix to resolve a 500 Internal Server Error that occurs when processing timeless reports (e.g., "Mirror Reports") through the Math Brain v2 pipeline. The v2 processor requires a date range, which was missing in these cases.

The fix modifies `app/api/astrology-mathbrain/route.ts` to inject a default single-day date range (using the current date) into the `v2Config` object if no `startDate` or `endDate` is provided in the request. This ensures that the v2 processor always receives a valid date range, preventing it from crashing.