### PR TITLE
Fix Math Brain v2 filename sanitization

### DIFF
--- a/src/formatter/create_markdown_reading.js
+++ b/src/formatter/create_markdown_reading.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { sanitizeForFilename } = require('../utils/sanitizeFilename.js');
 
 /**
  * Creates a self-contained Markdown reading file from a unified JSON data object.
@@ -71,7 +72,13 @@ function createMarkdownReading(inputJsonPath) {
   markdownContent += '4.  **Adhere to Your Voice**: Your language must be clear, agency-preserving, and non-predictive. Reflect the patterns; do not dictate the future.\n';
 
   // --- Write the final file ---
-  const outputFileName = `Woven_Reading_${run_metadata.person_a}_${run_metadata.person_b}_${run_metadata.date_range[0]}_to_${run_metadata.date_range[1]}.md`;
+  const safePersonA = sanitizeForFilename(run_metadata?.person_a, 'PersonA');
+  const safePersonB = sanitizeForFilename(run_metadata?.person_b, run_metadata?.person_b ? 'PersonB' : 'Solo');
+  const dateRange = Array.isArray(run_metadata?.date_range) ? run_metadata.date_range : [];
+  const safeStart = sanitizeForFilename(dateRange[0], 'start');
+  const safeEnd = sanitizeForFilename(dateRange[1], dateRange[0] ? 'end' : 'start');
+
+  const outputFileName = `Woven_Reading_${safePersonA}_${safePersonB}_${safeStart}_to_${safeEnd}.md`;
   const outputPath = path.join(path.dirname(inputJsonPath), outputFileName);
   fs.writeFileSync(outputPath, markdownContent);
   console.log(`[Formatter] Success! Formatted Markdown reading written to: ${outputPath}`);

--- a/src/math_brain/main.js
+++ b/src/math_brain/main.js
@@ -6,6 +6,7 @@ const { aggregate } = require('../seismograph');
 
 // Import metric label classifiers
 const { classifyMagnitude, classifyDirectionalBias } = require('../../lib/reporting/metric-labels');
+const { sanitizeForFilename } = require('../utils/sanitizeFilename.js');
 
 /**
  * Main orchestrator for the Math Brain v2 pipeline.
@@ -65,7 +66,10 @@ async function runMathBrain(configPath, transitData = null) {
   };
 
   // 7. Write to Disk
-  const outputFileName = `unified_output_${personA.name}_${personB ? personB.name : 'Solo'}_${new Date().toISOString().split('T')[0]}.json`;
+  const safePersonA = sanitizeForFilename(personA?.name, 'PersonA');
+  const safePersonB = personB ? sanitizeForFilename(personB.name, 'PersonB') : 'Solo';
+  const runDate = new Date().toISOString().split('T')[0];
+  const outputFileName = `unified_output_${safePersonA}_${safePersonB}_${runDate}.json`;
   const outputPath = path.join(path.dirname(configPath), outputFileName);
   fs.writeFileSync(outputPath, JSON.stringify(finalOutput, null, 2));
   console.log(`[Math Brain] Success! Unified output written to: ${outputPath}`);

--- a/src/utils/sanitizeFilename.js
+++ b/src/utils/sanitizeFilename.js
@@ -1,0 +1,19 @@
+function sanitizeForFilename(value, fallback = 'file') {
+  const raw = value === undefined || value === null ? '' : String(value);
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return fallback;
+  }
+
+  // Replace characters that are problematic for filenames across platforms
+  const sanitized = trimmed
+    .replace(/[\u0000-\u001F\u007F]/g, '') // control characters
+    .replace(/[<>:"/\\|?*]/g, '_') // reserved characters on Windows
+    .replace(/\s+/g, ' ') // collapse whitespace to single spaces
+    .replace(/\.+$/g, '') // avoid trailing periods which can be problematic on Windows
+    .trim();
+
+  return sanitized.length > 0 ? sanitized : fallback;
+}
+
+module.exports = { sanitizeForFilename };


### PR DESCRIPTION
## Summary
- add a shared filename sanitization helper and reuse it in Math Brain v2 export paths
- ensure API responses and markdown exports generate safe filenames for solo and dyad reports
- prevent filesystem errors when person names or placeholders contain reserved characters

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f0038940cc832f84f270235596d43d