### PR TITLE
Fix relational report downloads by adding context

### DIFF
--- a/app/math-brain/page.tsx
+++ b/app/math-brain/page.tsx
@@ -1935,51 +1935,64 @@ export default function MathBrainPage() {
     console.log('[downloadV2Markdown] Starting download...');
 
     try {
+      const payload: Record<string, any> = {
+        use_v2: true,
+        personA: {
+          name: personA.name,
+          year: personA.year,
+          month: personA.month,
+          day: personA.day,
+          hour: personA.hour,
+          minute: personA.minute,
+          city: personA.city,
+          state: personA.state,
+          nation: (personA as any).nation || 'US',
+          latitude: personA.latitude,
+          longitude: personA.longitude,
+          timezone: personA.timezone
+        },
+        personB: personB ? {
+          name: personB.name,
+          year: personB.year,
+          month: personB.month,
+          day: personB.day,
+          hour: personB.hour,
+          minute: personB.minute,
+          city: personB.city,
+          state: personB.state,
+          nation: (personB as any).nation || 'US',
+          latitude: personB.latitude,
+          longitude: personB.longitude,
+          timezone: personB.timezone
+        } : null,
+        window: {
+          start: startDate,
+          end: endDate,
+          step: step
+        },
+        context: {
+          mode: mode
+        }
+      };
+
+      if (RELATIONAL_MODES.includes(mode)) {
+        payload.relationship_context = {
+          type: relationshipType,
+          intimacy_tier: relationshipType === 'PARTNER' ? relationshipTier : undefined,
+          role: relationshipType !== 'PARTNER' ? relationshipRole : undefined,
+          contact_state: contactState,
+          ex_estranged: relationshipType === 'FRIEND' ? undefined : exEstranged,
+          notes: relationshipNotes || undefined,
+        };
+      }
+
       const response = await fetch('/api/astrology-mathbrain', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           'X-Math-Brain-Version': 'v2'
         },
-        body: JSON.stringify({
-          use_v2: true,
-          personA: {
-            name: personA.name,
-            year: personA.year,
-            month: personA.month,
-            day: personA.day,
-            hour: personA.hour,
-            minute: personA.minute,
-            city: personA.city,
-            state: personA.state,
-            nation: (personA as any).nation || 'US',
-            latitude: personA.latitude,
-            longitude: personA.longitude,
-            timezone: personA.timezone
-          },
-          personB: personB ? {
-            name: personB.name,
-            year: personB.year,
-            month: personB.month,
-            day: personB.day,
-            hour: personB.hour,
-            minute: personB.minute,
-            city: personB.city,
-            state: personB.state,
-            nation: (personB as any).nation || 'US',
-            latitude: personB.latitude,
-            longitude: personB.longitude,
-            timezone: personB.timezone
-          } : null,
-          window: {
-            start: startDate,
-            end: endDate,
-            step: step
-          },
-          context: {
-            mode: mode
-          }
-        })
+        body: JSON.stringify(payload)
       });
 
       // eslint-disable-next-line no-console
@@ -2043,51 +2056,64 @@ export default function MathBrainPage() {
     console.log('[downloadV2SymbolicWeather] Starting download...');
 
     try {
+      const payload: Record<string, any> = {
+        use_v2: true,
+        personA: {
+          name: personA.name,
+          year: personA.year,
+          month: personA.month,
+          day: personA.day,
+          hour: personA.hour,
+          minute: personA.minute,
+          city: personA.city,
+          state: personA.state,
+          nation: (personA as any).nation || 'US',
+          latitude: personA.latitude,
+          longitude: personA.longitude,
+          timezone: personA.timezone
+        },
+        personB: personB ? {
+          name: personB.name,
+          year: personB.year,
+          month: personB.month,
+          day: personB.day,
+          hour: personB.hour,
+          minute: personB.minute,
+          city: personB.city,
+          state: personB.state,
+          nation: (personB as any).nation || 'US',
+          latitude: personB.latitude,
+          longitude: personB.longitude,
+          timezone: personB.timezone
+        } : null,
+        window: {
+          start: startDate,
+          end: endDate,
+          step: step
+        },
+        context: {
+          mode: mode
+        }
+      };
+
+      if (RELATIONAL_MODES.includes(mode)) {
+        payload.relationship_context = {
+          type: relationshipType,
+          intimacy_tier: relationshipType === 'PARTNER' ? relationshipTier : undefined,
+          role: relationshipType !== 'PARTNER' ? relationshipRole : undefined,
+          contact_state: contactState,
+          ex_estranged: relationshipType === 'FRIEND' ? undefined : exEstranged,
+          notes: relationshipNotes || undefined,
+        };
+      }
+
       const response = await fetch('/api/astrology-mathbrain', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           'X-Math-Brain-Version': 'v2'
         },
-        body: JSON.stringify({
-          use_v2: true,
-          personA: {
-            name: personA.name,
-            year: personA.year,
-            month: personA.month,
-            day: personA.day,
-            hour: personA.hour,
-            minute: personA.minute,
-            city: personA.city,
-            state: personA.state,
-            nation: (personA as any).nation || 'US',
-            latitude: personA.latitude,
-            longitude: personA.longitude,
-            timezone: personA.timezone
-          },
-          personB: personB ? {
-            name: personB.name,
-            year: personB.year,
-            month: personB.month,
-            day: personB.day,
-            hour: personB.hour,
-            minute: personB.minute,
-            city: personB.city,
-            state: personB.state,
-            nation: (personB as any).nation || 'US',
-            latitude: personB.latitude,
-            longitude: personB.longitude,
-            timezone: personB.timezone
-          } : null,
-          window: {
-            start: startDate,
-            end: endDate,
-            step: step
-          },
-          context: {
-            mode: mode
-          }
-        })
+        body: JSON.stringify(payload)
       });
 
       // eslint-disable-next-line no-console


### PR DESCRIPTION
This commit fixes a bug that caused downloads of relational reports (Synastry, Composite) to fail with a "Relationship context invalid" error.

The download functions for V2 reports were making API calls without including the `relationship_context` object. This caused the server-side validation to fail, preventing the report from being generated.

This has been resolved by conditionally adding the `relationship_context` to the request payload for both the `downloadV2Markdown` and `downloadV2SymbolicWeather` functions in `app/math-brain/page.tsx` when a relational report is being downloaded.