### PR TITLE
Refactor: Consolidate Poetic Brain output into a single paragraph

### DIFF
--- a/__tests__/raven-geometry.test.ts
+++ b/__tests__/raven-geometry.test.ts
@@ -44,11 +44,17 @@ describe('AstroSeek geometry pipeline', () => {
     const geo = normalizeGeometry(parsed);
     const draft = await renderShareableMirror({ geo, prov: { source: 'AstroSeek (test)' }, options: {} });
 
+    // All conversational content is now in the 'picture' field.
     expect(draft.picture).toMatch(/Sun Aries/i);
     expect(draft.picture).toMatch(/Moon Taurus/i);
-    expect(draft.feeling).toMatch(/dense, deliberate weight/i);
-    expect(draft.option).toMatch(/tangible task/i);
-    expect(draft.next_step).toMatch(/Log one lived moment/i);
+    expect(draft.picture).toMatch(/dense, deliberate weight/i);
+    expect(draft.picture).toMatch(/tangible task/i);
+    expect(draft.picture).toMatch(/Log one lived moment/i);
+
+    // Other fields should be empty.
+    expect(draft.feeling).toBe('');
+    expect(draft.option).toBe('');
+    expect(draft.next_step).toBe('');
 
     expect(draft.appendix.geometry_summary).toContain('Placements parsed');
     expect(draft.appendix.primary_aspect).toMatch(/Sun Square Moon/i);

--- a/lib/raven/render.ts
+++ b/lib/raven/render.ts
@@ -623,12 +623,20 @@ export async function renderShareableMirror({ geo, prov, options, conversational
     }
   });
 
-  return {
+  const combinedParagraph = [
     picture,
     feeling,
     container,
     option,
-    next_step: nextStep,
+    nextStep
+  ].map(s => s.trim()).filter(Boolean).join('\n\n');
+
+  return {
+    picture: combinedParagraph,
+    feeling: '',
+    container: '',
+    option: '',
+    next_step: '',
     appendix,
   };
 }


### PR DESCRIPTION
The Poetic Brain's output was previously split into categorized chunks, which was unnatural to read. This change consolidates the `picture`, `feeling`, `container`, `option`, and `next_step` fields into a single, cohesive paragraph under the `picture` field. The other fields are cleared to prevent the UI from rendering them.

This improves the readability of the Poetic Brain's output without requiring any frontend changes.

I was unable to provide a screenshot of the frontend verification due to an unstable development environment. The application's flakiness prevented me from reliably generating a screenshot of the changes.