### PR TITLE
Add AI bundle ZIP export for Poetic Brain

### DIFF
--- a/app/math-brain/components/DownloadControls.tsx
+++ b/app/math-brain/components/DownloadControls.tsx
@@ -11,10 +11,12 @@ interface DownloadControlsProps {
   weatherJsonGenerating: boolean;
   engineConfigGenerating: boolean;
   cleanJsonGenerating: boolean;
+  bundleGenerating: boolean;
   onDownloadPDF: () => void;
   onDownloadMarkdown: () => void;
   onDownloadMirrorDirective: () => void;
   onDownloadSymbolicWeather: () => void;
+  onDownloadBundle: () => void;
   onDownloadGraphsPDF: () => void;
   onDownloadEngineConfig: () => void;
   onDownloadCleanJSON: () => void;
@@ -35,10 +37,12 @@ export default function DownloadControls({
   weatherJsonGenerating,
   engineConfigGenerating,
   cleanJsonGenerating,
+  bundleGenerating,
   onDownloadPDF,
   onDownloadMarkdown,
   onDownloadMirrorDirective,
   onDownloadSymbolicWeather,
+  onDownloadBundle,
   onDownloadGraphsPDF,
   onDownloadEngineConfig,
   onDownloadCleanJSON,
@@ -51,7 +55,14 @@ export default function DownloadControls({
   onNavigateToPoetic,
 }: DownloadControlsProps) {
   const hasSeismographData = Object.keys(seismographMap || {}).length > 0;
-  const isAnyGenerating = pdfGenerating || markdownGenerating || graphsPdfGenerating || weatherJsonGenerating || engineConfigGenerating || cleanJsonGenerating;
+  const isAnyGenerating =
+    pdfGenerating ||
+    markdownGenerating ||
+    graphsPdfGenerating ||
+    weatherJsonGenerating ||
+    engineConfigGenerating ||
+    cleanJsonGenerating ||
+    bundleGenerating;
 
   return (
     <>
@@ -79,6 +90,34 @@ export default function DownloadControls({
         <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-400">For Raven Calder (AI Analysis)</h3>
 
 
+
+        <button
+          type="button"
+          onClick={onDownloadBundle}
+          disabled={bundleGenerating}
+          className="w-full rounded-md border border-emerald-500 bg-emerald-600/20 px-4 py-3 text-left hover:bg-emerald-600/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 disabled:opacity-50 disabled:cursor-not-allowed transition"
+          aria-label="Download AI-ready ZIP bundle"
+          title="Includes README, Mirror Directive JSON, Symbolic Weather JSON, and FieldMap JSON"
+        >
+          <div className="flex items-center gap-3">
+            {bundleGenerating ? (
+              <svg className="animate-spin h-5 w-5 text-emerald-200" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+              </svg>
+            ) : (
+              <span className="text-2xl">📦</span>
+            )}
+            <div className="flex-1">
+              <div className="text-sm font-medium text-slate-100">
+                {bundleGenerating ? "Preparing AI bundle..." : "AI Analysis Bundle (ZIP)"}
+              </div>
+              <div className="text-xs text-slate-400 mt-0.5">
+                README + Mirror Directive + Symbolic Weather + FieldMap
+              </div>
+            </div>
+          </div>
+        </button>
 
         <button
           type="button"

--- a/app/math-brain/page.tsx
+++ b/app/math-brain/page.tsx
@@ -1165,7 +1165,7 @@ export default function MathBrainPage() {
 
   // User-friendly filename helper (Raven Calder naming system)
   const friendlyFilename = useCallback(
-    (type: 'directive' | 'dashboard' | 'symbolic-weather' | 'weather-log' | 'engine-config') => {
+    (type: 'directive' | 'dashboard' | 'symbolic-weather' | 'weather-log' | 'engine-config' | 'ai-bundle') => {
       const duo = includePersonB
         ? `${personASlug}-${personBSlug}`
         : personASlug;
@@ -1176,7 +1176,8 @@ export default function MathBrainPage() {
         'dashboard': 'Weather_Dashboard',
         'symbolic-weather': 'Symbolic_Weather_Dashboard',
         'weather-log': 'Weather_Log',
-        'engine-config': 'Engine_Configuration'
+        'engine-config': 'Engine_Configuration',
+        'ai-bundle': 'AI_Bundle',
       };
 
       return `${nameMap[type]}_${duo}_${dateStr}`;
@@ -1357,11 +1358,13 @@ export default function MathBrainPage() {
     downloadMirrorDirectiveJSON,
     downloadMapFile,
     downloadFieldFile,
+    downloadAIBundle,
     pdfGenerating,
     markdownGenerating,
     cleanJsonGenerating,
     engineConfigGenerating,
     weatherJsonGenerating,
+    bundleGenerating,
   } = useChartExport({
     result,
     reportType,
@@ -4671,10 +4674,12 @@ export default function MathBrainPage() {
             weatherJsonGenerating={weatherJsonGenerating}
             engineConfigGenerating={engineConfigGenerating}
             cleanJsonGenerating={cleanJsonGenerating}
+            bundleGenerating={bundleGenerating}
             onDownloadPDF={downloadResultPDF}
             onDownloadMarkdown={downloadResultMarkdown}
             onDownloadMirrorDirective={downloadMirrorDirectiveJSON}
             onDownloadSymbolicWeather={downloadSymbolicWeatherJSON}
+            onDownloadBundle={downloadAIBundle}
             onDownloadGraphsPDF={downloadGraphsPDF}
             onDownloadEngineConfig={downloadBackstageJSON}
             onDownloadCleanJSON={downloadResultJSON}


### PR DESCRIPTION
## Summary
- add an "AI Analysis Bundle" ZIP download option alongside existing Math Brain exports
- refactor export helpers to reuse directive, symbolic weather, and field map payload builders
- include a README and consolidated JSON files so external AIs can parse Poetic Brain compatible bundles

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68fdaf03ecc8832f941c4aed16322b35