### PR TITLE
Prevent Raven upload summary from emitting resonance probe

### DIFF
--- a/app/api/raven/route.ts
+++ b/app/api/raven/route.ts
@@ -126,12 +126,7 @@ export async function POST(req: Request) {
     const intent = detectIntent(textInput);
     const uploadedSummary = summariseUploadedReportJson(textInput);
     if (uploadedSummary) {
-      const { draft, prov, climateText, highlight } = uploadedSummary;
-      const probe = createProbe(
-        highlight || 'Mark one observation from this upload.',
-        randomUUID()
-      );
-      sessionLog.probes.push(probe);
+      const { draft, prov, climateText } = uploadedSummary;
       return NextResponse.json({
         intent: 'report',
         ok: true,
@@ -139,7 +134,7 @@ export async function POST(req: Request) {
         prov,
         climate: climateText ?? null,
         sessionId: sid,
-        probe,
+        probe: null,
       });
     }
     if (intent === 'geometry') {


### PR DESCRIPTION
## Summary
- stop generating a resonance probe when only acknowledging an uploaded report so the UI doesn't show premature scoring prompts

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_69054b2dc064832f938ee777697cec46