### PR TITLE
Improve Raven conversation mode handling

### DIFF
--- a/lib/raven/sst.ts
+++ b/lib/raven/sst.ts
@@ -15,10 +15,17 @@ export interface SessionTurn {
   createdAt: string;
 }
 
+export interface SessionSuggestion {
+  text: string;
+  acknowledged?: boolean;
+  createdAt: string;
+}
+
 export interface SessionSSTLog {
   probes: SSTProbe[];
   turnCount?: number;
   history?: SessionTurn[];
+  suggestions?: SessionSuggestion[];
 }
 
 export interface SessionScores {


### PR DESCRIPTION
## Summary
- add conversation mode classification for Raven sessions and track user suggestions in the session log
- adjust prompt guidance and fallback probes based on explanation, clarification, or suggestion modes
- expose stored suggestions via the export endpoint for later review

## Testing
- npm run test:raven-guard *(fails: test script expects a different runner and exits with SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_69055c23ae50832f8e1d70cabad5dee0