### PR TITLE
Fix missing MandateDiagnostic import in narrative builder

### DIFF
--- a/lib/poetics/narrative-builder.ts
+++ b/lib/poetics/narrative-builder.ts
@@ -6,7 +6,7 @@
  * Geometry-first, falsifiable phrasing; no deterministic claims
  */
 
-import type { MandateAspect, ChartMandates } from './types';
+import type { MandateAspect, ChartMandates, MandateDiagnostic } from './types';
 
 export interface PolarityCard {
   name: string;


### PR DESCRIPTION
## Summary
- import the MandateDiagnostic type into the narrative builder so the diagnostic helper compiles with TypeScript

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_690ac37f954c832f9ca180a69e7a6554