### PR TITLE
Fix Auth0 redirect callback default to Math Brain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,9 +83,9 @@ AUTH0_CLIENT_ID=your_auth0_client_id_here
 # Example: https://api.yourdomain.com or woven-api
 AUTH0_AUDIENCE=https://api.wovenwebapp.com
 
-# Optional override for Auth0 redirect callback path (default '/')
-# Example: /post-login
-NEXT_PUBLIC_AUTH_CALLBACK_PATH=/
+# Optional override for Auth0 redirect callback path (default '/math-brain')
+# Example: /post-login (must be added to Allowed Callback URLs in Auth0)
+NEXT_PUBLIC_AUTH_CALLBACK_PATH=/math-brain
 
 # Perplexity API Key (REQUIRED for Poetic Brain feature)
 # Get this from https://perplexity.ai/settings/api

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,7 +1,25 @@
 // Small shared utility for Auth0 redirect consistency
-// Send users back to home page after authentication
+// Send users back to Math Brain after authentication (default)
 
-const AUTH_CALLBACK_PATH = process.env.NEXT_PUBLIC_AUTH_CALLBACK_PATH?.trim() || '/';
+const DEFAULT_CALLBACK_PATH = '/math-brain';
+
+function normalizeCallbackPath(raw?: string | null): string {
+  if (!raw) return DEFAULT_CALLBACK_PATH;
+  const trimmed = raw.trim();
+  if (!trimmed) return DEFAULT_CALLBACK_PATH;
+
+  // Allow developers to specify a full URL (https://example.com/callback)
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+
+  // Ensure the path always starts with a single leading slash.
+  const normalized = `/${trimmed.replace(/^\/+/g, '')}`;
+  const withoutTrailing = normalized.replace(/\/+$/, '');
+  return withoutTrailing || '/';
+}
+
+const AUTH_CALLBACK_PATH = normalizeCallbackPath(process.env.NEXT_PUBLIC_AUTH_CALLBACK_PATH);
 
 export function getRedirectUri(): string {
   if (typeof window === 'undefined') {
@@ -10,10 +28,18 @@ export function getRedirectUri(): string {
   }
 
   try {
-    return new URL(AUTH_CALLBACK_PATH, window.location.origin).toString();
+    const target = AUTH_CALLBACK_PATH || DEFAULT_CALLBACK_PATH;
+    if (/^https?:\/\//i.test(target)) {
+      return target;
+    }
+    return new URL(target, window.location.origin).toString();
   } catch (err) {
     // Fallback to manual concatenation if URL construction fails (very unlikely)
+    const target = AUTH_CALLBACK_PATH || DEFAULT_CALLBACK_PATH;
+    if (/^https?:\/\//i.test(target)) {
+      return target;
+    }
     const origin = window.location.origin.replace(/\/$/, '');
-    return `${origin}${AUTH_CALLBACK_PATH}`;
+    return `${origin}${target.startsWith('/') ? target : `/${target}`}`;
   }
 }


### PR DESCRIPTION
## Summary
- default the shared Auth0 redirect helper to return the Math Brain page so the callback matches the allowed URLs
- normalize custom callback overrides (including full URLs) and document the new default in the sample env file

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690ac6188c2c832f91478abb518b5b44