### PR TITLE
Fix balance meter overflow detection tolerance

### DIFF
--- a/app/math-brain/hooks/useChartExport.ts
+++ b/app/math-brain/hooks/useChartExport.ts
@@ -67,7 +67,11 @@ import {
   formatChartTables,
   extractAxisNumber,
 } from '../utils/formatting';
-import { computeOverflowDetail } from '../../../lib/math-brain/overflow-detail';
+import {
+  computeOverflowDetail,
+  OVERFLOW_LIMIT,
+  OVERFLOW_TOLERANCE,
+} from '../../../lib/math-brain/overflow-detail';
 import { getDirectivePrefix, getDirectiveSuffix } from '../../../lib/export/filename-utils';
 
 type FriendlyFilenameType =
@@ -1474,12 +1478,22 @@ Start with the Solo Mirror(s), then ${
             coherence = Math.max(0, Math.min(5, Math.round(coherence * 10) / 10));
           }
 
+          const magnitudeClampedFlag =
+            typeof safeRawMag === 'number' && safeRawMag > OVERFLOW_LIMIT;
+          const directionalClampedFlag =
+            typeof safeRawBias === 'number' && Math.abs(safeRawBias) > OVERFLOW_LIMIT;
+          const saturationFlag =
+            typeof safeRawMag === 'number' && safeRawMag >= OVERFLOW_LIMIT - OVERFLOW_TOLERANCE;
+
           const overflowDetail = computeOverflowDetail({
             rawMagnitude: safeRawMag,
             clampedMagnitude: typeof safeRawMag === 'number' ? clamp(safeRawMag, 0, 5) : null,
             rawDirectionalBias: safeRawBias,
             clampedDirectionalBias:
               typeof safeRawBias === 'number' ? clamp(safeRawBias, -5, 5) : null,
+            magnitudeClamped: magnitudeClampedFlag,
+            directionalBiasClamped: directionalClampedFlag,
+            saturation: saturationFlag,
             aspects: (dayData as any).aspects,
           });
 

--- a/test/overflow-detail.test.ts
+++ b/test/overflow-detail.test.ts
@@ -34,6 +34,9 @@ describe('overflow detail exports', () => {
     expect(detail.note).toBe(OVERFLOW_NOTE_TEXT);
     expect(detail.drivers).toContain('Mars(Person A) ▻ Venus(Person B) Square');
     expect(detail.drivers).toContain('Sun ▻ Moon Trine');
+    expect(detail.overflowRegistered).toBe(true);
+    expect(detail.magnitude_clamped).toBe(false);
+    expect(detail.directional_clamped).toBe(false);
   });
 
   it('returns null when readings stay within bounds', () => {
@@ -42,6 +45,37 @@ describe('overflow detail exports', () => {
       clampedMagnitude: 4.999,
       rawDirectionalBias: -4.9,
       clampedDirectionalBias: -4.9,
+      aspects: [],
+    });
+
+    expect(detail).toBeNull();
+  });
+
+  it('uses clamp flags to report overflow near the tolerance band', () => {
+    const detail = computeOverflowDetail({
+      rawMagnitude: 5.02,
+      clampedMagnitude: 5,
+      rawDirectionalBias: -5.01,
+      clampedDirectionalBias: -5,
+      magnitudeClamped: true,
+      directionalBiasClamped: true,
+      aspects: [],
+    });
+
+    expect(detail).not.toBeNull();
+    if (!detail) return;
+
+    expect(detail.overflowRegistered).toBe(true);
+    expect(detail.magnitude_delta).toBeCloseTo(0.02, 2);
+    expect(detail.directional_delta).toBeCloseTo(-0.01, 2);
+  });
+
+  it('ignores unclamped jitter within the tolerance band', () => {
+    const detail = computeOverflowDetail({
+      rawMagnitude: 5.02,
+      clampedMagnitude: 5.02,
+      rawDirectionalBias: -5.01,
+      clampedDirectionalBias: -5.01,
       aspects: [],
     });
 


### PR DESCRIPTION
## Summary
- tighten overflow detail computation with tolerance-based range checks and clamp flags from seismograph data
- update the Balance Meter overflow banner to respect the new flag and format overshoot labels correctly
- extend chart export wiring and unit tests to cover clamp and near-limit scenarios

## Testing
- npm run test:vitest -- --run test/overflow-detail.test.ts

------
https://chatgpt.com/codex/tasks/task_e_690b0e556a40832fa9c52e8443a47e90