### PR TITLE
Fix seismograph typing and predeclare aspects for type checking

### DIFF
--- a/lib/math-brain/overflow-detail.ts
+++ b/lib/math-brain/overflow-detail.ts
@@ -301,12 +301,15 @@ export interface SeismographLike {
   rawMagnitude?: unknown;
   magnitude_before_clamp?: unknown;
   originalMagnitude?: unknown;
+  magnitude_clamped?: boolean;
+  magnitude_state?: { clamped?: boolean } | null;
   directional_bias?: any;
   rawDirectionalBias?: unknown;
   axes?: {
-    magnitude?: { raw?: unknown; value?: unknown; scaled?: unknown };
+    magnitude?: { raw?: unknown; value?: unknown; scaled?: unknown; clamped?: boolean };
     directional_bias?: { raw?: unknown; value?: unknown };
   };
+  saturation?: unknown;
   aspects?: unknown;
 }
 

--- a/lib/raven/render.ts
+++ b/lib/raven/render.ts
@@ -629,6 +629,8 @@ export async function renderShareableMirror({ geo, prov, options, conversational
     };
   }
 
+  const aspects = Array.isArray(geo.aspects) ? geo.aspects : [];
+
   if (!geometryValidatedInitial) {
     return {
       picture: 'Validation pending—geometry captured but not confirmed.',
@@ -646,7 +648,6 @@ export async function renderShareableMirror({ geo, prov, options, conversational
     };
   }
 
-  const aspects = Array.isArray(geo.aspects) ? geo.aspects : [];
   const summary = geo.summary;
 
   const primaryAspect = pickPrimaryAspect(aspects);


### PR DESCRIPTION
## Summary
- align the `SeismographLike` interface with clamping fields used during overflow analysis
- ensure the geometry validation response can reference aspects safely by declaring the array before use

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690c3789d1d0832faf381f84cd969f80