### PR TITLE
Add coverage for invalid birth data handling

### DIFF
--- a/__tests__/api/astrology-mathbrain-route.test.ts
+++ b/__tests__/api/astrology-mathbrain-route.test.ts
@@ -81,6 +81,7 @@ describe('Astrology Math Brain API route', () => {
       detail: 'Birth data missing coordinates',
     });
     expect(payload.error).toContain('Birth data appears invalid or incomplete');
+    expect(payload.hint).toContain('Verify that the birth date, time');
   });
 
   it('returns 503 with hint when RapidAPI key is missing', async () => {


### PR DESCRIPTION
## Summary
- extend the API route test to assert the invalid birth data failure response exposes the 422 status and hint text when the legacy handler rejects the payload

## Testing
- npx vitest run __tests__/api/astrology-mathbrain-route.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911b2279070832fbfc3a6febe200027)