### PR TITLE
Normalize Math Brain birth data payload

### DIFF
--- a/app/math-brain/page.tsx
+++ b/app/math-brain/page.tsx
@@ -261,14 +261,18 @@ const normalizeSubjectPayload = (subject: Subject, options: NormalizeSubjectOpti
   const day = toOptionalNumber(subject.day);
   if (day != null) normalized.day = day;
 
-  if (allowUnknownTime) {
+  const parsedHour = toOptionalNumber(subject.hour);
+  const parsedMinute = toOptionalNumber(subject.minute);
+
+  if (parsedHour != null && parsedMinute != null) {
+    normalized.hour = parsedHour;
+    normalized.minute = parsedMinute;
+  } else if (allowUnknownTime) {
     normalized.hour = null;
     normalized.minute = null;
   } else {
-    const hour = toOptionalNumber(subject.hour);
-    if (hour != null) normalized.hour = hour;
-    const minute = toOptionalNumber(subject.minute);
-    if (minute != null) normalized.minute = minute;
+    if (parsedHour != null) normalized.hour = parsedHour;
+    if (parsedMinute != null) normalized.minute = parsedMinute;
   }
 
   const latitude = toOptionalNumber(subject.latitude);


### PR DESCRIPTION
## Summary
- add helpers to sanitize math brain subject data before building API requests
- prevent empty birth fields from being serialized as zero values and honor unknown time selections
- trim textual birth inputs and keep defaults for nation/zodiac type when missing

## Testing
- npm run lint *(fails: Missing script "lint")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69123096955c832f9920c249d262c8a4)